### PR TITLE
fix: resolve httpx exception handling and lint issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ client = PolymarketUS(
 
 # Create an order
 order = client.orders.create({
-    "market_slug": "btc-100k-2025",
+    "marketSlug": "btc-100k-2025",
     "intent": "ORDER_INTENT_BUY_LONG",
     "type": "ORDER_TYPE_LIMIT",
     "price": {"value": "0.55", "currency": "USD"},
@@ -68,7 +68,7 @@ order = client.orders.create({
 open_orders = client.orders.list()
 
 # Cancel an order
-client.orders.cancel(order["id"], {"market_slug": "btc-100k-2025"})
+client.orders.cancel(order["id"], {"marketSlug": "btc-100k-2025"})
 
 # Cancel all orders
 client.orders.cancel_all()
@@ -126,6 +126,8 @@ client = PolymarketUS(
 ```python
 from polymarket_us import (
     PolymarketUS,
+    APIConnectionError,
+    APITimeoutError,
     AuthenticationError,
     BadRequestError,
     NotFoundError,
@@ -134,14 +136,18 @@ from polymarket_us import (
 
 try:
     client.orders.create({...})
-except AuthenticationError:
-    print("Invalid credentials")
-except BadRequestError:
-    print("Invalid order parameters")
-except RateLimitError:
-    print("Rate limit exceeded, retry later")
-except NotFoundError:
-    print("Resource not found")
+except AuthenticationError as e:
+    print(f"Invalid credentials: {e.message}")
+except BadRequestError as e:
+    print(f"Invalid order parameters: {e.message}")
+except RateLimitError as e:
+    print(f"Rate limit exceeded: {e.message}")
+except NotFoundError as e:
+    print(f"Resource not found: {e.message}")
+except APITimeoutError:
+    print("Request timed out")
+except APIConnectionError as e:
+    print(f"Connection error: {e.message}")
 ```
 
 ## Configuration
@@ -155,6 +161,9 @@ client = PolymarketUS(
 ```
 
 ### WebSocket (Real-Time Data)
+
+> **Note**: WebSocket connections are async-only due to their event-driven nature.
+> Use `asyncio.run()` when working with the sync client, or use `AsyncPolymarketUS` directly.
 
 ```python
 import asyncio
@@ -181,9 +190,9 @@ async def main():
     private_ws.on("error", lambda e: print(f"Error: {e}"))
 
     await private_ws.connect()
-    await private_ws.subscribe_orders("order-sub-1")
-    await private_ws.subscribe_positions("pos-sub-1")
-    await private_ws.subscribe_account_balance("balance-sub-1")
+    await private_ws.subscribe("order-sub-1", "SUBSCRIPTION_TYPE_ORDER")
+    await private_ws.subscribe("pos-sub-1", "SUBSCRIPTION_TYPE_POSITION")
+    await private_ws.subscribe("balance-sub-1", "SUBSCRIPTION_TYPE_ACCOUNT_BALANCE")
 
     # Markets WebSocket (order book, trades)
     markets_ws = client.ws.markets()
@@ -192,8 +201,8 @@ async def main():
     markets_ws.on("trade", lambda d: print(f"Trade: {d['trade']}"))
 
     await markets_ws.connect()
-    await markets_ws.subscribe_market_data("md-sub-1", ["btc-100k-2025"])
-    await markets_ws.subscribe_trades("trade-sub-1", ["btc-100k-2025"])
+    await markets_ws.subscribe("md-sub-1", "SUBSCRIPTION_TYPE_MARKET_DATA", ["btc-100k-2025"])
+    await markets_ws.subscribe("trade-sub-1", "SUBSCRIPTION_TYPE_TRADE", ["btc-100k-2025"])
 
     # Keep running
     await asyncio.sleep(60)
@@ -271,12 +280,14 @@ asyncio.run(main())
 |--------|-------------|
 | `search.query(params?)` | Search events (includes nested markets) |
 
-### WebSocket (Authenticated)
+### WebSocket (Authenticated, Async-Only)
 
 | Method | Description |
 |--------|-------------|
 | `ws.private()` | Create private WebSocket connection |
 | `ws.markets()` | Create markets WebSocket connection |
+
+WebSocket methods (`connect()`, `subscribe()`, `close()`) are async and must be awaited.
 
 **Private WebSocket Events:**
 - `order_snapshot` - Initial orders snapshot

--- a/polymarket_us/__init__.py
+++ b/polymarket_us/__init__.py
@@ -3,11 +3,15 @@
 from polymarket_us.async_client import AsyncPolymarketUS
 from polymarket_us.client import PolymarketUS
 from polymarket_us.errors import (
+    APIConnectionError,
     APIError,
+    APIStatusError,
+    APITimeoutError,
     AuthenticationError,
     BadRequestError,
     InternalServerError,
     NotFoundError,
+    PermissionDeniedError,
     PolymarketUSError,
     RateLimitError,
     WebSocketError,
@@ -20,8 +24,12 @@ __all__ = [
     # Errors
     "PolymarketUSError",
     "APIError",
+    "APIConnectionError",
+    "APITimeoutError",
+    "APIStatusError",
     "AuthenticationError",
     "BadRequestError",
+    "PermissionDeniedError",
     "NotFoundError",
     "RateLimitError",
     "InternalServerError",

--- a/polymarket_us/__init__.py
+++ b/polymarket_us/__init__.py
@@ -37,15 +37,8 @@ __all__ = [
 ]
 
 try:
-    from importlib.metadata import version
+    from importlib.metadata import version as _version
 
-    __version__ = version("polymarket-us")
-except ImportError:
-    # Fallback for Python < 3.8
-    try:
-        from importlib_metadata import version
-
-        __version__ = version("polymarket-us")
-    except ImportError:
-        # Fallback if package not installed
-        __version__ = "0.1.0"
+    __version__ = _version("polymarket-us")
+except Exception:
+    __version__ = "0.1.0"

--- a/polymarket_us/async_client.py
+++ b/polymarket_us/async_client.py
@@ -8,11 +8,14 @@ import httpx
 
 from polymarket_us.auth import create_auth_headers
 from polymarket_us.errors import (
-    APIError,
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
     AuthenticationError,
     BadRequestError,
     InternalServerError,
     NotFoundError,
+    PermissionDeniedError,
     RateLimitError,
 )
 from polymarket_us.resources import (
@@ -80,16 +83,7 @@ class AsyncPolymarketUS:
         query: dict[str, Any] | None = None,
         authenticated: bool = False,
     ) -> Any:
-        """Make a GET request.
-
-        Args:
-            path: Request path
-            query: Query parameters
-            authenticated: Whether to use authentication
-
-        Returns:
-            Response data
-        """
+        """Make a GET request."""
         return await self._request("GET", path, query=query, authenticated=authenticated)
 
     async def post(
@@ -100,17 +94,7 @@ class AsyncPolymarketUS:
         body: dict[str, Any] | None = None,
         authenticated: bool = False,
     ) -> Any:
-        """Make a POST request.
-
-        Args:
-            path: Request path
-            query: Query parameters
-            body: Request body
-            authenticated: Whether to use authentication
-
-        Returns:
-            Response data
-        """
+        """Make a POST request."""
         return await self._request(
             "POST", path, query=query, body=body, authenticated=authenticated
         )
@@ -122,16 +106,7 @@ class AsyncPolymarketUS:
         query: dict[str, Any] | None = None,
         authenticated: bool = False,
     ) -> Any:
-        """Make a DELETE request.
-
-        Args:
-            path: Request path
-            query: Query parameters
-            authenticated: Whether to use authentication
-
-        Returns:
-            Response data
-        """
+        """Make a DELETE request."""
         return await self._request("DELETE", path, query=query, authenticated=authenticated)
 
     async def _request(
@@ -143,18 +118,7 @@ class AsyncPolymarketUS:
         body: dict[str, Any] | None = None,
         authenticated: bool = False,
     ) -> Any:
-        """Make an HTTP request.
-
-        Args:
-            method: HTTP method
-            path: Request path
-            query: Query parameters
-            body: Request body
-            authenticated: Whether to use authentication
-
-        Returns:
-            Response data
-        """
+        """Make an HTTP request."""
         base_url = self.api_base_url if authenticated else self.gateway_base_url
         url = f"{base_url}{path}"
 
@@ -164,21 +128,26 @@ class AsyncPolymarketUS:
             if not self.key_id or not self.secret_key:
                 raise AuthenticationError(
                     "API key credentials required for authenticated endpoints. "
-                    "Provide key_id and secret_key when initializing the client."
+                    "Provide key_id and secret_key when initializing the client.",
+                    response=_make_fake_response(401, url),
                 )
             auth_headers = create_auth_headers(self.key_id, self.secret_key, method, path)
             headers.update(auth_headers)
 
-        # Build query params, filtering None values
         params = self._build_query_params(query) if query else None
 
-        response = await self._http.request(
-            method,
-            url,
-            params=params,
-            json=body,
-            headers=headers,
-        )
+        try:
+            response = await self._http.request(
+                method,
+                url,
+                params=params,
+                json=body,
+                headers=headers,
+            )
+        except httpx.TimeoutException as e:
+            raise APITimeoutError(request=getattr(e, "_request", None))
+        except httpx.ConnectError as e:
+            raise APIConnectionError(message=str(e), request=getattr(e, "_request", None))
 
         if not response.is_success:
             self._handle_error_response(response)
@@ -206,25 +175,31 @@ class AsyncPolymarketUS:
 
     def _handle_error_response(self, response: httpx.Response) -> None:
         """Handle error response from the API."""
+        body: object | None = None
         try:
-            data = response.json()
-            message = data.get("message") or data.get("error") or response.reason_phrase
+            body = response.json()
+            if isinstance(body, dict):
+                message = body.get("message") or body.get("error") or response.reason_phrase
+            else:
+                message = response.reason_phrase or "Unknown error"
         except Exception:
             message = response.text or response.reason_phrase or "Unknown error"
 
         status = response.status_code
         if status == 400:
-            raise BadRequestError(message)
+            raise BadRequestError(message, response=response, body=body)
         elif status == 401:
-            raise AuthenticationError(message)
+            raise AuthenticationError(message, response=response, body=body)
+        elif status == 403:
+            raise PermissionDeniedError(message, response=response, body=body)
         elif status == 404:
-            raise NotFoundError(message)
+            raise NotFoundError(message, response=response, body=body)
         elif status == 429:
-            raise RateLimitError(message)
+            raise RateLimitError(message, response=response, body=body)
         elif status >= 500:
-            raise InternalServerError(message)
+            raise InternalServerError(message, response=response, body=body)
         else:
-            raise APIError(status, message)
+            raise APIStatusError(message, response=response, body=body)
 
     async def close(self) -> None:
         """Close the HTTP client."""
@@ -247,9 +222,9 @@ class _AsyncWebSocketFactory:
         if not self._client.key_id or not self._client.secret_key:
             raise AuthenticationError(
                 "API key credentials required for WebSocket connections. "
-                "Provide key_id and secret_key when initializing the client."
+                "Provide key_id and secret_key when initializing the client.",
+                response=_make_fake_response(401, "wss://api.polymarket.us"),
             )
-        # Convert HTTP URL to WebSocket URL
         url = self._client.api_base_url.replace("https://", "wss://").replace("http://", "ws://")
         return {
             "key_id": self._client.key_id,
@@ -268,3 +243,8 @@ class _AsyncWebSocketFactory:
         from polymarket_us.websocket import MarketsWebSocket
 
         return MarketsWebSocket(**self._get_ws_options())
+
+
+def _make_fake_response(status_code: int, url: str) -> httpx.Response:
+    """Create a fake response for errors raised before making a request."""
+    return httpx.Response(status_code=status_code, request=httpx.Request("GET", url))

--- a/polymarket_us/client.py
+++ b/polymarket_us/client.py
@@ -8,11 +8,14 @@ import httpx
 
 from polymarket_us.auth import create_auth_headers
 from polymarket_us.errors import (
-    APIError,
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
     AuthenticationError,
     BadRequestError,
     InternalServerError,
     NotFoundError,
+    PermissionDeniedError,
     RateLimitError,
 )
 from polymarket_us.resources import (
@@ -80,16 +83,7 @@ class PolymarketUS:
         query: dict[str, Any] | None = None,
         authenticated: bool = False,
     ) -> Any:
-        """Make a GET request.
-
-        Args:
-            path: Request path
-            query: Query parameters
-            authenticated: Whether to use authentication
-
-        Returns:
-            Response data
-        """
+        """Make a GET request."""
         return self._request("GET", path, query=query, authenticated=authenticated)
 
     def post(
@@ -100,17 +94,7 @@ class PolymarketUS:
         body: dict[str, Any] | None = None,
         authenticated: bool = False,
     ) -> Any:
-        """Make a POST request.
-
-        Args:
-            path: Request path
-            query: Query parameters
-            body: Request body
-            authenticated: Whether to use authentication
-
-        Returns:
-            Response data
-        """
+        """Make a POST request."""
         return self._request("POST", path, query=query, body=body, authenticated=authenticated)
 
     def delete(
@@ -120,16 +104,7 @@ class PolymarketUS:
         query: dict[str, Any] | None = None,
         authenticated: bool = False,
     ) -> Any:
-        """Make a DELETE request.
-
-        Args:
-            path: Request path
-            query: Query parameters
-            authenticated: Whether to use authentication
-
-        Returns:
-            Response data
-        """
+        """Make a DELETE request."""
         return self._request("DELETE", path, query=query, authenticated=authenticated)
 
     def _request(
@@ -141,18 +116,7 @@ class PolymarketUS:
         body: dict[str, Any] | None = None,
         authenticated: bool = False,
     ) -> Any:
-        """Make an HTTP request.
-
-        Args:
-            method: HTTP method
-            path: Request path
-            query: Query parameters
-            body: Request body
-            authenticated: Whether to use authentication
-
-        Returns:
-            Response data
-        """
+        """Make an HTTP request."""
         base_url = self.api_base_url if authenticated else self.gateway_base_url
         url = f"{base_url}{path}"
 
@@ -162,21 +126,26 @@ class PolymarketUS:
             if not self.key_id or not self.secret_key:
                 raise AuthenticationError(
                     "API key credentials required for authenticated endpoints. "
-                    "Provide key_id and secret_key when initializing the client."
+                    "Provide key_id and secret_key when initializing the client.",
+                    response=_make_fake_response(401, url),
                 )
             auth_headers = create_auth_headers(self.key_id, self.secret_key, method, path)
             headers.update(auth_headers)
 
-        # Build query params, filtering None values
         params = self._build_query_params(query) if query else None
 
-        response = self._http.request(
-            method,
-            url,
-            params=params,
-            json=body,
-            headers=headers,
-        )
+        try:
+            response = self._http.request(
+                method,
+                url,
+                params=params,
+                json=body,
+                headers=headers,
+            )
+        except httpx.TimeoutException as e:
+            raise APITimeoutError(request=getattr(e, "_request", None))
+        except httpx.ConnectError as e:
+            raise APIConnectionError(message=str(e), request=getattr(e, "_request", None))
 
         if not response.is_success:
             self._handle_error_response(response)
@@ -204,25 +173,31 @@ class PolymarketUS:
 
     def _handle_error_response(self, response: httpx.Response) -> None:
         """Handle error response from the API."""
+        body: object | None = None
         try:
-            data = response.json()
-            message = data.get("message") or data.get("error") or response.reason_phrase
+            body = response.json()
+            if isinstance(body, dict):
+                message = body.get("message") or body.get("error") or response.reason_phrase
+            else:
+                message = response.reason_phrase or "Unknown error"
         except Exception:
             message = response.text or response.reason_phrase or "Unknown error"
 
         status = response.status_code
         if status == 400:
-            raise BadRequestError(message)
+            raise BadRequestError(message, response=response, body=body)
         elif status == 401:
-            raise AuthenticationError(message)
+            raise AuthenticationError(message, response=response, body=body)
+        elif status == 403:
+            raise PermissionDeniedError(message, response=response, body=body)
         elif status == 404:
-            raise NotFoundError(message)
+            raise NotFoundError(message, response=response, body=body)
         elif status == 429:
-            raise RateLimitError(message)
+            raise RateLimitError(message, response=response, body=body)
         elif status >= 500:
-            raise InternalServerError(message)
+            raise InternalServerError(message, response=response, body=body)
         else:
-            raise APIError(status, message)
+            raise APIStatusError(message, response=response, body=body)
 
     def close(self) -> None:
         """Close the HTTP client."""
@@ -245,9 +220,9 @@ class _WebSocketFactory:
         if not self._client.key_id or not self._client.secret_key:
             raise AuthenticationError(
                 "API key credentials required for WebSocket connections. "
-                "Provide key_id and secret_key when initializing the client."
+                "Provide key_id and secret_key when initializing the client.",
+                response=_make_fake_response(401, "wss://api.polymarket.us"),
             )
-        # Convert HTTP URL to WebSocket URL
         url = self._client.api_base_url.replace("https://", "wss://").replace("http://", "ws://")
         return {
             "key_id": self._client.key_id,
@@ -266,3 +241,8 @@ class _WebSocketFactory:
         from polymarket_us.websocket import MarketsWebSocket
 
         return MarketsWebSocket(**self._get_ws_options())
+
+
+def _make_fake_response(status_code: int, url: str) -> httpx.Response:
+    """Create a fake response for errors raised before making a request."""
+    return httpx.Response(status_code=status_code, request=httpx.Request("GET", url))

--- a/polymarket_us/errors.py
+++ b/polymarket_us/errors.py
@@ -66,8 +66,7 @@ class APIStatusError(APIError):
 
     def __repr__(self) -> str:
         return (
-            f"{self.__class__.__name__}"
-            f"(status_code={self.status_code}, message={self.message!r})"
+            f"{self.__class__.__name__}(status_code={self.status_code}, message={self.message!r})"
         )
 
 

--- a/polymarket_us/errors.py
+++ b/polymarket_us/errors.py
@@ -1,5 +1,7 @@
 """Exception classes for Polymarket US SDK."""
 
+import httpx
+
 
 class PolymarketUSError(Exception):
     """Base exception for Polymarket US SDK errors."""
@@ -10,48 +12,99 @@ class PolymarketUSError(Exception):
 class APIError(PolymarketUSError):
     """Error returned by the API."""
 
-    def __init__(self, status: int, message: str, code: str | None = None) -> None:
+    message: str
+    request: httpx.Request | None
+    body: object | None
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        request: httpx.Request | None = None,
+        body: object | None = None,
+    ) -> None:
         super().__init__(message)
-        self.status = status
-        self.code = code
+        self.message = message
+        self.request = request
+        self.body = body
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(status={self.status}, message={str(self)!r})"
+        return f"{self.__class__.__name__}(message={self.message!r})"
 
 
-class AuthenticationError(APIError):
-    """Authentication failed (401)."""
+class APIConnectionError(APIError):
+    """Network connection error."""
 
-    def __init__(self, message: str = "Authentication failed") -> None:
-        super().__init__(401, message, "authentication_error")
+    def __init__(
+        self,
+        *,
+        message: str = "Connection error.",
+        request: httpx.Request | None = None,
+    ) -> None:
+        super().__init__(message, request=request, body=None)
 
 
-class BadRequestError(APIError):
+class APITimeoutError(APIConnectionError):
+    """Request timed out."""
+
+    def __init__(self, *, request: httpx.Request | None = None) -> None:
+        super().__init__(message="Request timed out.", request=request)
+
+
+class APIStatusError(APIError):
+    """HTTP 4xx/5xx response."""
+
+    response: httpx.Response
+    status_code: int
+
+    def __init__(
+        self, message: str, *, response: httpx.Response, body: object | None = None
+    ) -> None:
+        super().__init__(message, request=response.request, body=body)
+        self.response = response
+        self.status_code = response.status_code
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}"
+            f"(status_code={self.status_code}, message={self.message!r})"
+        )
+
+
+class BadRequestError(APIStatusError):
     """Bad request (400)."""
 
-    def __init__(self, message: str = "Bad request") -> None:
-        super().__init__(400, message, "bad_request")
+    pass
 
 
-class NotFoundError(APIError):
+class AuthenticationError(APIStatusError):
+    """Authentication failed (401)."""
+
+    pass
+
+
+class PermissionDeniedError(APIStatusError):
+    """Permission denied (403)."""
+
+    pass
+
+
+class NotFoundError(APIStatusError):
     """Resource not found (404)."""
 
-    def __init__(self, message: str = "Resource not found") -> None:
-        super().__init__(404, message, "not_found")
+    pass
 
 
-class RateLimitError(APIError):
+class RateLimitError(APIStatusError):
     """Rate limit exceeded (429)."""
 
-    def __init__(self, message: str = "Rate limit exceeded") -> None:
-        super().__init__(429, message, "rate_limit_exceeded")
+    pass
 
 
-class InternalServerError(APIError):
+class InternalServerError(APIStatusError):
     """Internal server error (500+)."""
 
-    def __init__(self, message: str = "Internal server error") -> None:
-        super().__init__(500, message, "internal_server_error")
+    pass
 
 
 class WebSocketError(PolymarketUSError):

--- a/polymarket_us/resource.py
+++ b/polymarket_us/resource.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from polymarket_us.async_client import AsyncPolymarketUS
@@ -16,49 +15,9 @@ class APIResource:
     def __init__(self, client: PolymarketUS) -> None:
         self._client = client
 
-    def _to_camel_case(self, snake_str: str) -> str:
-        """Convert snake_case to camelCase."""
-        components = snake_str.split("_")
-        return components[0] + "".join(x.title() for x in components[1:])
-
-    def _convert_params(
-        self, params: Mapping[str, Any] | None
-    ) -> dict[str, Any] | None:
-        """Convert snake_case params to camelCase for the API."""
-        if not params:
-            return None
-        result: dict[str, Any] = {}
-        for key, value in params.items():
-            camel_key = self._to_camel_case(key)
-            if isinstance(value, dict):
-                result[camel_key] = self._convert_params(value)
-            else:
-                result[camel_key] = value
-        return result
-
 
 class AsyncAPIResource:
     """Base class for API resources (async)."""
 
     def __init__(self, client: AsyncPolymarketUS) -> None:
         self._client = client
-
-    def _to_camel_case(self, snake_str: str) -> str:
-        """Convert snake_case to camelCase."""
-        components = snake_str.split("_")
-        return components[0] + "".join(x.title() for x in components[1:])
-
-    def _convert_params(
-        self, params: Mapping[str, Any] | None
-    ) -> dict[str, Any] | None:
-        """Convert snake_case params to camelCase for the API."""
-        if not params:
-            return None
-        result: dict[str, Any] = {}
-        for key, value in params.items():
-            camel_key = self._to_camel_case(key)
-            if isinstance(value, dict):
-                result[camel_key] = self._convert_params(value)
-            else:
-                result[camel_key] = value
-        return result

--- a/polymarket_us/resources/events.py
+++ b/polymarket_us/resources/events.py
@@ -8,36 +8,15 @@ class Events(APIResource):
     """Events API resource."""
 
     def list(self, params: EventsListParams | None = None) -> GetEventsResponse:
-        """List events with optional filtering.
-
-        Args:
-            params: Optional filtering and pagination parameters
-
-        Returns:
-            Response containing list of events
-        """
-        return self._client.get("/v1/events", query=self._convert_params(params))
+        """List events with optional filtering."""
+        return self._client.get("/v1/events", query=dict(params) if params else None)
 
     def retrieve(self, id: int) -> GetEventResponse:
-        """Get an event by ID.
-
-        Args:
-            id: Event ID
-
-        Returns:
-            Response containing the event
-        """
+        """Get an event by ID."""
         return self._client.get(f"/v1/events/{id}")
 
     def retrieve_by_slug(self, slug: str) -> GetEventResponse:
-        """Get an event by slug.
-
-        Args:
-            slug: Event slug
-
-        Returns:
-            Response containing the event
-        """
+        """Get an event by slug."""
         return self._client.get(f"/v1/events/slug/{slug}")
 
 
@@ -45,34 +24,13 @@ class AsyncEvents(AsyncAPIResource):
     """Events API resource (async)."""
 
     async def list(self, params: EventsListParams | None = None) -> GetEventsResponse:
-        """List events with optional filtering.
-
-        Args:
-            params: Optional filtering and pagination parameters
-
-        Returns:
-            Response containing list of events
-        """
-        return await self._client.get("/v1/events", query=self._convert_params(params))
+        """List events with optional filtering."""
+        return await self._client.get("/v1/events", query=dict(params) if params else None)
 
     async def retrieve(self, id: int) -> GetEventResponse:
-        """Get an event by ID.
-
-        Args:
-            id: Event ID
-
-        Returns:
-            Response containing the event
-        """
+        """Get an event by ID."""
         return await self._client.get(f"/v1/events/{id}")
 
     async def retrieve_by_slug(self, slug: str) -> GetEventResponse:
-        """Get an event by slug.
-
-        Args:
-            slug: Event slug
-
-        Returns:
-            Response containing the event
-        """
+        """Get an event by slug."""
         return await self._client.get(f"/v1/events/slug/{slug}")

--- a/polymarket_us/resources/markets.py
+++ b/polymarket_us/resources/markets.py
@@ -15,69 +15,27 @@ class Markets(APIResource):
     """Markets API resource."""
 
     def list(self, params: MarketsListParams | None = None) -> GetMarketsResponse:
-        """List markets with optional filtering.
-
-        Args:
-            params: Optional filtering and pagination parameters
-
-        Returns:
-            Response containing list of markets
-        """
-        return self._client.get("/v1/markets", query=self._convert_params(params))
+        """List markets with optional filtering."""
+        return self._client.get("/v1/markets", query=dict(params) if params else None)
 
     def retrieve(self, id: int) -> GetMarketResponse:
-        """Get a market by ID.
-
-        Args:
-            id: Market ID
-
-        Returns:
-            Response containing the market
-        """
+        """Get a market by ID."""
         return self._client.get(f"/v1/market/id/{id}")
 
     def retrieve_by_slug(self, slug: str) -> GetMarketResponse:
-        """Get a market by slug.
-
-        Args:
-            slug: Market slug
-
-        Returns:
-            Response containing the market
-        """
+        """Get a market by slug."""
         return self._client.get(f"/v1/market/slug/{slug}")
 
     def book(self, slug: str) -> MarketBook:
-        """Get order book for a market.
-
-        Args:
-            slug: Market slug
-
-        Returns:
-            Order book with bids and offers
-        """
+        """Get order book for a market."""
         return self._client.get(f"/v1/markets/{slug}/book")
 
     def bbo(self, slug: str) -> MarketBBO:
-        """Get best bid/offer for a market.
-
-        Args:
-            slug: Market slug
-
-        Returns:
-            Best bid/offer data
-        """
+        """Get best bid/offer for a market."""
         return self._client.get(f"/v1/markets/{slug}/bbo")
 
     def settlement(self, slug: str) -> MarketSettlement:
-        """Get settlement information for a market.
-
-        Args:
-            slug: Market slug
-
-        Returns:
-            Settlement information
-        """
+        """Get settlement information for a market."""
         return self._client.get(f"/v1/markets/{slug}/settlement")
 
 
@@ -85,67 +43,25 @@ class AsyncMarkets(AsyncAPIResource):
     """Markets API resource (async)."""
 
     async def list(self, params: MarketsListParams | None = None) -> GetMarketsResponse:
-        """List markets with optional filtering.
-
-        Args:
-            params: Optional filtering and pagination parameters
-
-        Returns:
-            Response containing list of markets
-        """
-        return await self._client.get("/v1/markets", query=self._convert_params(params))
+        """List markets with optional filtering."""
+        return await self._client.get("/v1/markets", query=dict(params) if params else None)
 
     async def retrieve(self, id: int) -> GetMarketResponse:
-        """Get a market by ID.
-
-        Args:
-            id: Market ID
-
-        Returns:
-            Response containing the market
-        """
+        """Get a market by ID."""
         return await self._client.get(f"/v1/market/id/{id}")
 
     async def retrieve_by_slug(self, slug: str) -> GetMarketResponse:
-        """Get a market by slug.
-
-        Args:
-            slug: Market slug
-
-        Returns:
-            Response containing the market
-        """
+        """Get a market by slug."""
         return await self._client.get(f"/v1/market/slug/{slug}")
 
     async def book(self, slug: str) -> MarketBook:
-        """Get order book for a market.
-
-        Args:
-            slug: Market slug
-
-        Returns:
-            Order book with bids and offers
-        """
+        """Get order book for a market."""
         return await self._client.get(f"/v1/markets/{slug}/book")
 
     async def bbo(self, slug: str) -> MarketBBO:
-        """Get best bid/offer for a market.
-
-        Args:
-            slug: Market slug
-
-        Returns:
-            Best bid/offer data
-        """
+        """Get best bid/offer for a market."""
         return await self._client.get(f"/v1/markets/{slug}/bbo")
 
     async def settlement(self, slug: str) -> MarketSettlement:
-        """Get settlement information for a market.
-
-        Args:
-            slug: Market slug
-
-        Returns:
-            Settlement information
-        """
+        """Get settlement information for a market."""
         return await self._client.get(f"/v1/markets/{slug}/settlement")

--- a/polymarket_us/resources/orders.py
+++ b/polymarket_us/resources/orders.py
@@ -22,114 +22,62 @@ class Orders(APIResource):
     """Orders API resource (requires authentication)."""
 
     def create(self, params: CreateOrderParams) -> CreateOrderResponse:
-        """Create a new order.
-
-        Args:
-            params: Order parameters
-
-        Returns:
-            Response containing order ID and optional executions
-        """
+        """Create a new order."""
         return self._client.post(
             "/v1/orders",
-            body=self._convert_params(dict(params)),
+            body=dict(params),
             authenticated=True,
         )
 
     def list(self, params: GetOpenOrdersParams | None = None) -> GetOpenOrdersResponse:
-        """List open orders.
-
-        Args:
-            params: Optional filtering parameters
-
-        Returns:
-            Response containing list of open orders
-        """
+        """List open orders."""
         return self._client.get(
             "/v1/orders/open",
-            query=self._convert_params(params),
+            query=dict(params) if params else None,
             authenticated=True,
         )
 
     def retrieve(self, order_id: str) -> GetOrderResponse:
-        """Get an order by ID.
-
-        Args:
-            order_id: Order ID
-
-        Returns:
-            Response containing the order
-        """
+        """Get an order by ID."""
         return self._client.get(f"/v1/order/{order_id}", authenticated=True)
 
     def cancel(self, order_id: str, params: CancelOrderParams) -> None:
-        """Cancel an order.
-
-        Args:
-            order_id: Order ID to cancel
-            params: Cancel parameters (requires market_slug)
-        """
+        """Cancel an order."""
         self._client.post(
             f"/v1/order/{order_id}/cancel",
-            body=self._convert_params(dict(params)),
+            body=dict(params),
             authenticated=True,
         )
 
     def modify(self, order_id: str, params: ModifyOrderParams) -> None:
-        """Modify an order.
-
-        Args:
-            order_id: Order ID to modify
-            params: Modification parameters
-        """
+        """Modify an order."""
         self._client.post(
             f"/v1/order/{order_id}/modify",
-            body=self._convert_params(dict(params)),
+            body=dict(params),
             authenticated=True,
         )
 
     def cancel_all(self, params: CancelAllOrdersParams | None = None) -> CancelAllOrdersResponse:
-        """Cancel all open orders.
-
-        Args:
-            params: Optional parameters to filter which orders to cancel
-
-        Returns:
-            Response containing IDs of canceled orders
-        """
+        """Cancel all open orders."""
         return self._client.post(
             "/v1/orders/open/cancel",
-            body=self._convert_params(dict(params)) if params else {},
+            body=dict(params) if params else {},
             authenticated=True,
         )
 
     def preview(self, params: PreviewOrderParams) -> PreviewOrderResponse:
-        """Preview an order before creating it.
-
-        Args:
-            params: Order parameters to preview
-
-        Returns:
-            Response containing the previewed order
-        """
+        """Preview an order before creating it."""
         return self._client.post(
             "/v1/order/preview",
-            body=self._convert_params(dict(params)),
+            body=dict(params),
             authenticated=True,
         )
 
     def close_position(self, params: ClosePositionParams) -> ClosePositionResponse:
-        """Close a position.
-
-        Args:
-            params: Close position parameters
-
-        Returns:
-            Response containing order ID and optional executions
-        """
+        """Close a position."""
         return self._client.post(
             "/v1/order/close-position",
-            body=self._convert_params(dict(params)),
+            body=dict(params),
             authenticated=True,
         )
 
@@ -138,115 +86,63 @@ class AsyncOrders(AsyncAPIResource):
     """Orders API resource (async, requires authentication)."""
 
     async def create(self, params: CreateOrderParams) -> CreateOrderResponse:
-        """Create a new order.
-
-        Args:
-            params: Order parameters
-
-        Returns:
-            Response containing order ID and optional executions
-        """
+        """Create a new order."""
         return await self._client.post(
             "/v1/orders",
-            body=self._convert_params(dict(params)),
+            body=dict(params),
             authenticated=True,
         )
 
     async def list(self, params: GetOpenOrdersParams | None = None) -> GetOpenOrdersResponse:
-        """List open orders.
-
-        Args:
-            params: Optional filtering parameters
-
-        Returns:
-            Response containing list of open orders
-        """
+        """List open orders."""
         return await self._client.get(
             "/v1/orders/open",
-            query=self._convert_params(params),
+            query=dict(params) if params else None,
             authenticated=True,
         )
 
     async def retrieve(self, order_id: str) -> GetOrderResponse:
-        """Get an order by ID.
-
-        Args:
-            order_id: Order ID
-
-        Returns:
-            Response containing the order
-        """
+        """Get an order by ID."""
         return await self._client.get(f"/v1/order/{order_id}", authenticated=True)
 
     async def cancel(self, order_id: str, params: CancelOrderParams) -> None:
-        """Cancel an order.
-
-        Args:
-            order_id: Order ID to cancel
-            params: Cancel parameters (requires market_slug)
-        """
+        """Cancel an order."""
         await self._client.post(
             f"/v1/order/{order_id}/cancel",
-            body=self._convert_params(dict(params)),
+            body=dict(params),
             authenticated=True,
         )
 
     async def modify(self, order_id: str, params: ModifyOrderParams) -> None:
-        """Modify an order.
-
-        Args:
-            order_id: Order ID to modify
-            params: Modification parameters
-        """
+        """Modify an order."""
         await self._client.post(
             f"/v1/order/{order_id}/modify",
-            body=self._convert_params(dict(params)),
+            body=dict(params),
             authenticated=True,
         )
 
     async def cancel_all(
         self, params: CancelAllOrdersParams | None = None
     ) -> CancelAllOrdersResponse:
-        """Cancel all open orders.
-
-        Args:
-            params: Optional parameters to filter which orders to cancel
-
-        Returns:
-            Response containing IDs of canceled orders
-        """
+        """Cancel all open orders."""
         return await self._client.post(
             "/v1/orders/open/cancel",
-            body=self._convert_params(dict(params)) if params else {},
+            body=dict(params) if params else {},
             authenticated=True,
         )
 
     async def preview(self, params: PreviewOrderParams) -> PreviewOrderResponse:
-        """Preview an order before creating it.
-
-        Args:
-            params: Order parameters to preview
-
-        Returns:
-            Response containing the previewed order
-        """
+        """Preview an order before creating it."""
         return await self._client.post(
             "/v1/order/preview",
-            body=self._convert_params(dict(params)),
+            body=dict(params),
             authenticated=True,
         )
 
     async def close_position(self, params: ClosePositionParams) -> ClosePositionResponse:
-        """Close a position.
-
-        Args:
-            params: Close position parameters
-
-        Returns:
-            Response containing order ID and optional executions
-        """
+        """Close a position."""
         return await self._client.post(
             "/v1/order/close-position",
-            body=self._convert_params(dict(params)),
+            body=dict(params),
             authenticated=True,
         )

--- a/polymarket_us/resources/portfolio.py
+++ b/polymarket_us/resources/portfolio.py
@@ -13,32 +13,18 @@ class Portfolio(APIResource):
     """Portfolio API resource (requires authentication)."""
 
     def positions(self, params: GetUserPositionsParams | None = None) -> GetUserPositionsResponse:
-        """Get trading positions.
-
-        Args:
-            params: Optional filtering parameters
-
-        Returns:
-            Response containing positions
-        """
+        """Get trading positions."""
         return self._client.get(
             "/v1/portfolio/positions",
-            query=self._convert_params(params),
+            query=dict(params) if params else None,
             authenticated=True,
         )
 
     def activities(self, params: GetActivitiesParams | None = None) -> GetActivitiesResponse:
-        """Get activity history.
-
-        Args:
-            params: Optional filtering parameters
-
-        Returns:
-            Response containing activities
-        """
+        """Get activity history."""
         return self._client.get(
             "/v1/portfolio/activities",
-            query=self._convert_params(params),
+            query=dict(params) if params else None,
             authenticated=True,
         )
 
@@ -49,31 +35,17 @@ class AsyncPortfolio(AsyncAPIResource):
     async def positions(
         self, params: GetUserPositionsParams | None = None
     ) -> GetUserPositionsResponse:
-        """Get trading positions.
-
-        Args:
-            params: Optional filtering parameters
-
-        Returns:
-            Response containing positions
-        """
+        """Get trading positions."""
         return await self._client.get(
             "/v1/portfolio/positions",
-            query=self._convert_params(params),
+            query=dict(params) if params else None,
             authenticated=True,
         )
 
     async def activities(self, params: GetActivitiesParams | None = None) -> GetActivitiesResponse:
-        """Get activity history.
-
-        Args:
-            params: Optional filtering parameters
-
-        Returns:
-            Response containing activities
-        """
+        """Get activity history."""
         return await self._client.get(
             "/v1/portfolio/activities",
-            query=self._convert_params(params),
+            query=dict(params) if params else None,
             authenticated=True,
         )

--- a/polymarket_us/resources/search.py
+++ b/polymarket_us/resources/search.py
@@ -8,27 +8,13 @@ class Search(APIResource):
     """Search API resource."""
 
     def query(self, params: SearchParams | None = None) -> SearchResponse:
-        """Search for events.
-
-        Args:
-            params: Optional search parameters
-
-        Returns:
-            Response containing matching events
-        """
-        return self._client.get("/v1/search", query=self._convert_params(params))
+        """Search for events."""
+        return self._client.get("/v1/search", query=dict(params) if params else None)
 
 
 class AsyncSearch(AsyncAPIResource):
     """Search API resource (async)."""
 
     async def query(self, params: SearchParams | None = None) -> SearchResponse:
-        """Search for events.
-
-        Args:
-            params: Optional search parameters
-
-        Returns:
-            Response containing matching events
-        """
-        return await self._client.get("/v1/search", query=self._convert_params(params))
+        """Search for events."""
+        return await self._client.get("/v1/search", query=dict(params) if params else None)

--- a/polymarket_us/resources/series.py
+++ b/polymarket_us/resources/series.py
@@ -8,25 +8,11 @@ class Series(APIResource):
     """Series API resource."""
 
     def list(self, params: SeriesListParams | None = None) -> GetSeriesListResponse:
-        """List series with optional filtering.
-
-        Args:
-            params: Optional filtering and pagination parameters
-
-        Returns:
-            Response containing list of series
-        """
-        return self._client.get("/v1/series", query=self._convert_params(params))
+        """List series with optional filtering."""
+        return self._client.get("/v1/series", query=dict(params) if params else None)
 
     def retrieve(self, id: int) -> GetSeriesResponse:
-        """Get a series by ID.
-
-        Args:
-            id: Series ID
-
-        Returns:
-            Response containing the series
-        """
+        """Get a series by ID."""
         return self._client.get(f"/v1/series/id/{id}")
 
 
@@ -34,23 +20,9 @@ class AsyncSeries(AsyncAPIResource):
     """Series API resource (async)."""
 
     async def list(self, params: SeriesListParams | None = None) -> GetSeriesListResponse:
-        """List series with optional filtering.
-
-        Args:
-            params: Optional filtering and pagination parameters
-
-        Returns:
-            Response containing list of series
-        """
-        return await self._client.get("/v1/series", query=self._convert_params(params))
+        """List series with optional filtering."""
+        return await self._client.get("/v1/series", query=dict(params) if params else None)
 
     async def retrieve(self, id: int) -> GetSeriesResponse:
-        """Get a series by ID.
-
-        Args:
-            id: Series ID
-
-        Returns:
-            Response containing the series
-        """
+        """Get a series by ID."""
         return await self._client.get(f"/v1/series/id/{id}")

--- a/polymarket_us/resources/sports.py
+++ b/polymarket_us/resources/sports.py
@@ -12,45 +12,23 @@ class Sports(APIResource):
     """Sports API resource."""
 
     def list(self) -> GetSportsResponse:
-        """List all sports.
-
-        Returns:
-            Response containing list of sports
-        """
+        """List all sports."""
         return self._client.get("/v1/sports")
 
     def teams(self, params: GetSportsTeamsParams | None = None) -> GetSportsTeamsResponse:
-        """Get teams for a provider.
-
-        Args:
-            params: Optional parameters to filter teams
-
-        Returns:
-            Response containing teams
-        """
-        return self._client.get("/v1/sports/teams/provider", query=self._convert_params(params))
+        """Get teams for a provider."""
+        return self._client.get("/v1/sports/teams/provider", query=dict(params) if params else None)
 
 
 class AsyncSports(AsyncAPIResource):
     """Sports API resource (async)."""
 
     async def list(self) -> GetSportsResponse:
-        """List all sports.
-
-        Returns:
-            Response containing list of sports
-        """
+        """List all sports."""
         return await self._client.get("/v1/sports")
 
     async def teams(self, params: GetSportsTeamsParams | None = None) -> GetSportsTeamsResponse:
-        """Get teams for a provider.
-
-        Args:
-            params: Optional parameters to filter teams
-
-        Returns:
-            Response containing teams
-        """
+        """Get teams for a provider."""
         return await self._client.get(
-            "/v1/sports/teams/provider", query=self._convert_params(params)
+            "/v1/sports/teams/provider", query=dict(params) if params else None
         )

--- a/polymarket_us/types/account.py
+++ b/polymarket_us/types/account.py
@@ -11,26 +11,26 @@ class PendingWithdrawal(TypedDict, total=False):
     balance: float
     description: str
     acknowledged: bool
-    bank_id: str
-    creation_time: str
-    destination_account_name: str
+    bankId: str
+    creationTime: str
+    destinationAccountName: str
 
 
 class UserBalance(TypedDict, total=False):
     """User account balance."""
 
-    current_balance: float
+    currentBalance: float
     currency: str
-    last_updated: str
-    buying_power: float
-    asset_notional: float
-    asset_available: float
-    pending_credit: float
-    open_orders: float
-    unsettled_funds: float
-    pending_withdrawals: list[PendingWithdrawal]
-    margin_requirement: float
-    balance_reservation: float
+    lastUpdated: str
+    buyingPower: float
+    assetNotional: float
+    assetAvailable: float
+    pendingCredit: float
+    openOrders: float
+    unsettledFunds: float
+    pendingWithdrawals: list[PendingWithdrawal]
+    marginRequirement: float
+    balanceReservation: float
 
 
 class GetAccountBalancesResponse(TypedDict):

--- a/polymarket_us/types/events.py
+++ b/polymarket_us/types/events.py
@@ -41,8 +41,8 @@ class Event(TypedDict, total=False):
     slug: str
     title: str
     description: str
-    start_time: str
-    end_time: str
+    startTime: str
+    endTime: str
     active: bool
     closed: bool
     archived: bool
@@ -57,31 +57,31 @@ class Event(TypedDict, total=False):
 class EventsListParams(PaginationParams, total=False):
     """Parameters for listing events."""
 
-    order_by: list[str]
-    order_direction: Literal["asc", "desc"]
+    orderBy: list[str]
+    orderDirection: Literal["asc", "desc"]
     id: list[int]
     slug: list[str]
     archived: bool
     active: bool
     closed: bool
-    liquidity_min: float
-    liquidity_max: float
-    volume_min: float
-    volume_max: float
-    start_date_min: str
-    start_date_max: str
-    end_date_min: str
-    end_date_max: str
-    tag_id: int
-    tag_slug: str
-    related_tags: bool
+    liquidityMin: float
+    liquidityMax: float
+    volumeMin: float
+    volumeMax: float
+    startDateMin: str
+    startDateMax: str
+    endDateMin: str
+    endDateMax: str
+    tagId: int
+    tagSlug: str
+    relatedTags: bool
     featured: bool
-    series_id: list[int]
-    event_date: str
-    event_week: int
-    start_time_min: str
-    start_time_max: str
-    game_id: int
+    seriesId: list[int]
+    eventDate: str
+    eventWeek: int
+    startTimeMin: str
+    startTimeMax: str
+    gameId: int
     ended: bool
     categories: list[str]
 

--- a/polymarket_us/types/markets.py
+++ b/polymarket_us/types/markets.py
@@ -15,10 +15,10 @@ class Team(TypedDict, total=False):
     record: str
     logo: str
     alias: str
-    safe_name: str
-    home_icon: str
-    away_icon: str
-    color_primary: str
+    safeName: str
+    homeIcon: str
+    awayIcon: str
+    colorPrimary: str
 
 
 class MarketDetail(TypedDict, total=False):
@@ -33,7 +33,7 @@ class MarketDetail(TypedDict, total=False):
     closed: bool
     liquidity: float
     volume: float
-    event_slug: str
+    eventSlug: str
     team: Team
 
 
@@ -47,11 +47,11 @@ class OrderBookLevel(TypedDict):
 class MarketStats(TypedDict, total=False):
     """Market statistics."""
 
-    last_trade_px: Amount
-    shares_traded: str
-    open_interest: str
-    high_px: Amount
-    low_px: Amount
+    lastTradePx: Amount
+    sharesTraded: str
+    openInterest: str
+    highPx: Amount
+    lowPx: Amount
 
 
 MarketState = Literal[
@@ -68,51 +68,51 @@ MarketState = Literal[
 class MarketBook(TypedDict, total=False):
     """Order book for a market."""
 
-    market_slug: str
+    marketSlug: str
     bids: list[OrderBookLevel]
     offers: list[OrderBookLevel]
     state: MarketState
     stats: MarketStats
-    transact_time: str
+    transactTime: str
 
 
 class MarketBBO(TypedDict, total=False):
     """Best bid/offer for a market."""
 
-    market_slug: str
-    best_bid: Amount
-    best_ask: Amount
-    bid_depth: int
-    ask_depth: int
-    last_trade_px: Amount
-    shares_traded: str
-    open_interest: str
+    marketSlug: str
+    bestBid: Amount
+    bestAsk: Amount
+    bidDepth: int
+    askDepth: int
+    lastTradePx: Amount
+    sharesTraded: str
+    openInterest: str
 
 
 class MarketSettlement(TypedDict):
     """Market settlement information."""
 
-    market_slug: str
-    settlement_price: Amount
-    settled_at: str
+    marketSlug: str
+    settlementPrice: Amount
+    settledAt: str
 
 
 class MarketsListParams(PaginationParams, total=False):
     """Parameters for listing markets."""
 
-    order_by: list[str]
-    order_direction: Literal["asc", "desc"]
+    orderBy: list[str]
+    orderDirection: Literal["asc", "desc"]
     id: list[int]
     slug: list[str]
-    event_slug: list[str]
+    eventSlug: list[str]
     archived: bool
     active: bool
     closed: bool
-    liquidity_min: float
-    liquidity_max: float
-    volume_min: float
-    volume_max: float
-    game_id: int
+    liquidityMin: float
+    liquidityMax: float
+    volumeMin: float
+    volumeMax: float
+    gameId: int
     categories: list[str]
 
 

--- a/polymarket_us/types/orders.py
+++ b/polymarket_us/types/orders.py
@@ -50,7 +50,7 @@ ManualOrderIndicator = Literal[
 class SlippageTolerance(TypedDict, total=False):
     """Slippage tolerance for market orders."""
 
-    current_price: Amount
+    currentPrice: Amount
     bips: int
     ticks: int
 
@@ -62,34 +62,34 @@ class MarketMetadata(TypedDict, total=False):
     icon: str
     title: str
     outcome: str
-    event_slug: str
-    team_id: int
-    team: dict[str, object]  # Team info
+    eventSlug: str
+    teamId: int
+    team: dict[str, object]
 
 
 class Order(TypedDict, total=False):
     """Order details."""
 
     id: str
-    market_slug: str
+    marketSlug: str
     side: OrderSide
     type: OrderType
     price: Amount
     quantity: int
-    cum_quantity: int
-    leaves_quantity: int
+    cumQuantity: int
+    leavesQuantity: int
     tif: TimeInForce
-    good_till_time: str
+    goodTillTime: str
     intent: OrderIntent
-    market_metadata: MarketMetadata
+    marketMetadata: MarketMetadata
     state: OrderState
-    avg_px: Amount
-    cash_order_qty: Amount
-    insert_time: str
-    create_time: str
-    commission_notional_total_collected: Amount
-    commissions_basis_points: str
-    maker_commissions_basis_points: str
+    avgPx: Amount
+    cashOrderQty: Amount
+    insertTime: str
+    createTime: str
+    commissionNotionalTotalCollected: Amount
+    commissionsBasisPoints: str
+    makerCommissionsBasisPoints: str
 
 
 class Execution(TypedDict, total=False):
@@ -97,33 +97,33 @@ class Execution(TypedDict, total=False):
 
     id: str
     order: Order
-    last_shares: str
-    last_px: Amount
+    lastShares: str
+    lastPx: Amount
     type: ExecutionType
     text: str
-    order_reject_reason: str
-    transact_time: str
-    trade_id: str
+    orderRejectReason: str
+    transactTime: str
+    tradeId: str
     aggressor: bool
-    commission_notional_collected: Amount
+    commissionNotionalCollected: Amount
 
 
 class CreateOrderParams(TypedDict, total=False):
     """Parameters for creating an order."""
 
-    market_slug: str  # Required
+    marketSlug: str  # Required
     intent: OrderIntent  # Required
     type: OrderType
     price: Amount
     quantity: int
     tif: TimeInForce
-    participate_dont_initiate: bool
-    good_till_time: str
-    cash_order_qty: Amount
-    manual_order_indicator: ManualOrderIndicator
-    synchronous_execution: bool
-    max_block_time: str
-    slippage_tolerance: SlippageTolerance
+    participateDontInitiate: bool
+    goodTillTime: str
+    cashOrderQty: Amount
+    manualOrderIndicator: ManualOrderIndicator
+    synchronousExecution: bool
+    maxBlockTime: str
+    slippageTolerance: SlippageTolerance
 
 
 class CreateOrderResponse(TypedDict, total=False):
@@ -136,18 +136,18 @@ class CreateOrderResponse(TypedDict, total=False):
 class ModifyOrderParams(TypedDict, total=False):
     """Parameters for modifying an order."""
 
-    market_slug: str  # Required
+    marketSlug: str  # Required
     price: Amount
     quantity: int
     tif: TimeInForce
-    participate_dont_initiate: bool
-    good_till_time: str
+    participateDontInitiate: bool
+    goodTillTime: str
 
 
 class CancelOrderParams(TypedDict):
     """Parameters for canceling an order."""
 
-    market_slug: str
+    marketSlug: str
 
 
 class CancelAllOrdersParams(TypedDict, total=False):
@@ -159,7 +159,7 @@ class CancelAllOrdersParams(TypedDict, total=False):
 class CancelAllOrdersResponse(TypedDict):
     """Response from canceling all orders."""
 
-    canceled_order_ids: list[str]
+    canceledOrderIds: list[str]
 
 
 class GetOpenOrdersParams(TypedDict, total=False):
@@ -195,11 +195,11 @@ class PreviewOrderResponse(TypedDict):
 class ClosePositionParams(TypedDict, total=False):
     """Parameters for closing a position."""
 
-    market_slug: str  # Required
-    manual_order_indicator: ManualOrderIndicator
-    synchronous_execution: bool
-    max_block_time: str
-    slippage_tolerance: SlippageTolerance
+    marketSlug: str  # Required
+    manualOrderIndicator: ManualOrderIndicator
+    synchronousExecution: bool
+    maxBlockTime: str
+    slippageTolerance: SlippageTolerance
 
 
 class ClosePositionResponse(TypedDict, total=False):

--- a/polymarket_us/types/portfolio.py
+++ b/polymarket_us/types/portfolio.py
@@ -21,17 +21,17 @@ SortOrder = Literal["SORT_ORDER_DESCENDING", "SORT_ORDER_ASCENDING"]
 class UserPosition(TypedDict, total=False):
     """User position details."""
 
-    net_position: str
-    qty_bought: str
-    qty_sold: str
+    netPosition: str
+    qtyBought: str
+    qtySold: str
     cost: Amount
     realized: Amount
-    bod_position: str
+    bodPosition: str
     expired: bool
-    update_time: str
-    market_metadata: MarketMetadata
-    cash_value: Amount
-    qty_available: str
+    updateTime: str
+    marketMetadata: MarketMetadata
+    cashValue: Amount
+    qtyAvailable: str
 
 
 class GetUserPositionsParams(TypedDict, total=False):
@@ -46,7 +46,7 @@ class GetUserPositionsResponse(TypedDict, total=False):
     """Response for getting user positions."""
 
     positions: dict[str, UserPosition]
-    next_cursor: str
+    nextCursor: str
     eof: bool
 
 
@@ -54,36 +54,36 @@ class Trade(TypedDict, total=False):
     """Trade details."""
 
     id: str
-    market_slug: str
+    marketSlug: str
     state: str
-    create_time: str
-    update_time: str
+    createTime: str
+    updateTime: str
     price: Amount
     qty: str
-    is_aggressor: bool
-    cost_basis: Amount
-    realized_pnl: Amount
+    isAggressor: bool
+    costBasis: Amount
+    realizedPnl: Amount
 
 
 class PositionResolution(TypedDict, total=False):
     """Position resolution details."""
 
-    market_slug: str
-    before_position: UserPosition
-    after_position: UserPosition
-    update_time: str
-    trade_id: str
+    marketSlug: str
+    beforePosition: UserPosition
+    afterPosition: UserPosition
+    updateTime: str
+    tradeId: str
     side: str
 
 
 class AccountBalanceChangeTransaction(TypedDict, total=False):
     """Account balance change transaction."""
 
-    transaction_id: str
+    transactionId: str
     status: str
     amount: Amount
-    update_time: str
-    create_time: str
+    updateTime: str
+    createTime: str
 
 
 class AccountBalanceChange(TypedDict, total=False):
@@ -97,8 +97,8 @@ class Activity(TypedDict, total=False):
 
     type: ActivityType
     trade: Trade
-    position_resolution: PositionResolution
-    account_balance_change: AccountBalanceChange
+    positionResolution: PositionResolution
+    accountBalanceChange: AccountBalanceChange
 
 
 class GetActivitiesParams(TypedDict, total=False):
@@ -106,14 +106,14 @@ class GetActivitiesParams(TypedDict, total=False):
 
     limit: int
     cursor: str
-    market_slug: str
+    marketSlug: str
     types: list[ActivityType]
-    sort_order: SortOrder
+    sortOrder: SortOrder
 
 
 class GetActivitiesResponse(TypedDict, total=False):
     """Response for getting activities."""
 
     activities: list[Activity]
-    next_cursor: str
+    nextCursor: str
     eof: bool

--- a/polymarket_us/types/search.py
+++ b/polymarket_us/types/search.py
@@ -10,7 +10,7 @@ class SearchParams(TypedDict, total=False):
 
     query: str
     limit: int
-    series_ids: list[int]
+    seriesIds: list[int]
     status: Literal["active", "closed", "upcoming"]
     page: int
 

--- a/polymarket_us/types/series.py
+++ b/polymarket_us/types/series.py
@@ -21,8 +21,8 @@ class Series(TypedDict, total=False):
 class SeriesListParams(PaginationParams, total=False):
     """Parameters for listing series."""
 
-    order_by: list[str]
-    order_direction: Literal["asc", "desc"]
+    orderBy: list[str]
+    orderDirection: Literal["asc", "desc"]
     slug: list[str]
     archived: bool
     active: bool

--- a/polymarket_us/types/sports.py
+++ b/polymarket_us/types/sports.py
@@ -37,11 +37,11 @@ class SportsTeam(TypedDict, total=False):
     record: str
     logo: str
     alias: str
-    safe_name: str
-    home_icon: str
-    away_icon: str
-    color_primary: str
-    provider_ids: list[SportsTeamProvider]
+    safeName: str
+    homeIcon: str
+    awayIcon: str
+    colorPrimary: str
+    providerIds: list[SportsTeamProvider]
 
 
 class GetSportsResponse(TypedDict):
@@ -53,7 +53,7 @@ class GetSportsResponse(TypedDict):
 class GetSportsTeamsParams(TypedDict, total=False):
     """Parameters for getting teams."""
 
-    team_ids: list[str]
+    teamIds: list[str]
     provider: str
     league: str
 

--- a/polymarket_us/websocket/types.py
+++ b/polymarket_us/websocket/types.py
@@ -18,9 +18,9 @@ MarketSubscriptionType = Literal[
 
 
 class _SubscribePayload(TypedDict, total=False):
-    request_id: str
-    subscription_type: PrivateSubscriptionType | MarketSubscriptionType
-    market_slugs: list[str]
+    requestId: str
+    subscriptionType: PrivateSubscriptionType | MarketSubscriptionType
+    marketSlugs: list[str]
 
 
 class SubscribeRequest(TypedDict):
@@ -30,7 +30,7 @@ class SubscribeRequest(TypedDict):
 
 
 class _UnsubscribePayload(TypedDict):
-    request_id: str
+    requestId: str
 
 
 class UnsubscribeRequest(TypedDict):
@@ -50,9 +50,9 @@ class _OrderSubscriptionSnapshot(TypedDict):
 class OrderSnapshot(TypedDict):
     """Order snapshot message."""
 
-    request_id: str
-    subscription_type: Literal["SUBSCRIPTION_TYPE_ORDER"]
-    order_subscription_snapshot: _OrderSubscriptionSnapshot
+    requestId: str
+    subscriptionType: Literal["SUBSCRIPTION_TYPE_ORDER"]
+    orderSubscriptionSnapshot: _OrderSubscriptionSnapshot
 
 
 class _OrderSubscriptionUpdate(TypedDict):
@@ -62,9 +62,9 @@ class _OrderSubscriptionUpdate(TypedDict):
 class OrderUpdate(TypedDict):
     """Order update message."""
 
-    request_id: str
-    subscription_type: Literal["SUBSCRIPTION_TYPE_ORDER"]
-    order_subscription_update: _OrderSubscriptionUpdate
+    requestId: str
+    subscriptionType: Literal["SUBSCRIPTION_TYPE_ORDER"]
+    orderSubscriptionUpdate: _OrderSubscriptionUpdate
 
 
 class _PositionSubscriptionSnapshot(TypedDict):
@@ -75,48 +75,48 @@ class _PositionSubscriptionSnapshot(TypedDict):
 class PositionSnapshot(TypedDict):
     """Position snapshot message."""
 
-    request_id: str
-    subscription_type: Literal["SUBSCRIPTION_TYPE_POSITION"]
-    position_subscription_snapshot: _PositionSubscriptionSnapshot
+    requestId: str
+    subscriptionType: Literal["SUBSCRIPTION_TYPE_POSITION"]
+    positionSubscriptionSnapshot: _PositionSubscriptionSnapshot
 
 
 class _PositionSubscriptionUpdate(TypedDict):
-    market_slug: str
+    marketSlug: str
     position: UserPosition
 
 
 class PositionUpdate(TypedDict):
     """Position update message."""
 
-    request_id: str
-    subscription_type: Literal["SUBSCRIPTION_TYPE_POSITION"]
-    position_subscription_update: _PositionSubscriptionUpdate
+    requestId: str
+    subscriptionType: Literal["SUBSCRIPTION_TYPE_POSITION"]
+    positionSubscriptionUpdate: _PositionSubscriptionUpdate
 
 
 class _AccountBalanceSubscriptionSnapshot(TypedDict):
     balance: float
-    buying_power: float
+    buyingPower: float
 
 
 class AccountBalanceSnapshot(TypedDict):
     """Account balance snapshot message."""
 
-    request_id: str
-    subscription_type: Literal["SUBSCRIPTION_TYPE_ACCOUNT_BALANCE"]
-    account_balance_subscription_snapshot: _AccountBalanceSubscriptionSnapshot
+    requestId: str
+    subscriptionType: Literal["SUBSCRIPTION_TYPE_ACCOUNT_BALANCE"]
+    accountBalanceSubscriptionSnapshot: _AccountBalanceSubscriptionSnapshot
 
 
 class _AccountBalanceSubscriptionUpdate(TypedDict):
     balance: float
-    buying_power: float
+    buyingPower: float
 
 
 class AccountBalanceUpdate(TypedDict):
     """Account balance update message."""
 
-    request_id: str
-    subscription_type: Literal["SUBSCRIPTION_TYPE_ACCOUNT_BALANCE"]
-    account_balance_subscription_update: _AccountBalanceSubscriptionUpdate
+    requestId: str
+    subscriptionType: Literal["SUBSCRIPTION_TYPE_ACCOUNT_BALANCE"]
+    accountBalanceSubscriptionUpdate: _AccountBalanceSubscriptionUpdate
 
 
 class _OrderBookLevel(TypedDict):
@@ -125,43 +125,43 @@ class _OrderBookLevel(TypedDict):
 
 
 class _MarketDataStats(TypedDict, total=False):
-    last_trade_px: Amount
-    shares_traded: str
-    open_interest: str
-    high_px: Amount
-    low_px: Amount
+    lastTradePx: Amount
+    sharesTraded: str
+    openInterest: str
+    highPx: Amount
+    lowPx: Amount
 
 
 class _MarketDataPayload(TypedDict, total=False):
-    market_slug: str
+    marketSlug: str
     bids: list[_OrderBookLevel]
     offers: list[_OrderBookLevel]
     state: str
     stats: _MarketDataStats
-    transact_time: str
+    transactTime: str
 
 
 class MarketData(TypedDict):
     """Market data message (full order book)."""
 
-    request_id: str
-    subscription_type: Literal["SUBSCRIPTION_TYPE_MARKET_DATA"]
-    market_data: _MarketDataPayload
+    requestId: str
+    subscriptionType: Literal["SUBSCRIPTION_TYPE_MARKET_DATA"]
+    marketData: _MarketDataPayload
 
 
 class _MarketDataLitePayload(TypedDict, total=False):
-    market_slug: str
-    best_bid: Amount
-    best_ask: Amount
-    last_trade_px: Amount
+    marketSlug: str
+    bestBid: Amount
+    bestAsk: Amount
+    lastTradePx: Amount
 
 
 class MarketDataLite(TypedDict):
     """Market data lite message (best prices only)."""
 
-    request_id: str
-    subscription_type: Literal["SUBSCRIPTION_TYPE_MARKET_DATA_LITE"]
-    market_data_lite: _MarketDataLitePayload
+    requestId: str
+    subscriptionType: Literal["SUBSCRIPTION_TYPE_MARKET_DATA_LITE"]
+    marketDataLite: _MarketDataLitePayload
 
 
 class _TradeSide(TypedDict):
@@ -170,10 +170,10 @@ class _TradeSide(TypedDict):
 
 
 class _TradePayload(TypedDict):
-    market_slug: str
+    marketSlug: str
     price: Amount
     quantity: Amount
-    trade_time: str
+    tradeTime: str
     maker: _TradeSide
     taker: _TradeSide
 
@@ -181,8 +181,8 @@ class _TradePayload(TypedDict):
 class Trade(TypedDict):
     """Trade message."""
 
-    request_id: str
-    subscription_type: Literal["SUBSCRIPTION_TYPE_TRADE"]
+    requestId: str
+    subscriptionType: Literal["SUBSCRIPTION_TYPE_TRADE"]
     trade: _TradePayload
 
 
@@ -195,7 +195,7 @@ class Heartbeat(TypedDict):
 class WebSocketErrorMessage(TypedDict, total=False):
     """Error message."""
 
-    request_id: str
+    requestId: str
     error: str
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,15 +1,26 @@
 """Tests for error classes."""
 
+import httpx
+
 from polymarket_us import (
+    APIConnectionError,
     APIError,
+    APIStatusError,
+    APITimeoutError,
     AuthenticationError,
     BadRequestError,
     InternalServerError,
     NotFoundError,
+    PermissionDeniedError,
     PolymarketUSError,
     RateLimitError,
     WebSocketError,
 )
+
+
+def _make_response(status_code: int) -> httpx.Response:
+    """Create a mock response."""
+    return httpx.Response(status_code=status_code, request=httpx.Request("GET", "http://test"))
 
 
 class TestPolymarketUSError:
@@ -29,86 +40,141 @@ class TestPolymarketUSError:
 class TestAPIError:
     """Tests for APIError."""
 
-    def test_stores_status(self) -> None:
-        """Should store status code."""
-        error = APIError(500, "error")
-        assert error.status == 500
+    def test_stores_message(self) -> None:
+        """Should store message."""
+        error = APIError("test error")
+        assert error.message == "test error"
 
-    def test_stores_code(self) -> None:
-        """Should store error code."""
-        error = APIError(400, "error", "bad_request")
-        assert error.code == "bad_request"
+    def test_stores_body(self) -> None:
+        """Should store body."""
+        error = APIError("error", body={"code": "test"})
+        assert error.body == {"code": "test"}
 
     def test_is_polymarket_error(self) -> None:
         """Should be a PolymarketUSError."""
-        error = APIError(500, "error")
+        error = APIError("error")
         assert isinstance(error, PolymarketUSError)
 
 
-class TestAuthenticationError:
-    """Tests for AuthenticationError."""
+class TestAPIConnectionError:
+    """Tests for APIConnectionError."""
 
     def test_default_message(self) -> None:
         """Should have default message."""
-        error = AuthenticationError()
-        assert "Authentication failed" in str(error)
+        error = APIConnectionError()
+        assert "Connection error" in error.message
 
-    def test_status_is_401(self) -> None:
-        """Should have 401 status."""
-        error = AuthenticationError()
-        assert error.status == 401
+    def test_is_api_error(self) -> None:
+        """Should be an APIError."""
+        error = APIConnectionError()
+        assert isinstance(error, APIError)
 
-    def test_code_is_authentication_error(self) -> None:
-        """Should have authentication_error code."""
-        error = AuthenticationError()
-        assert error.code == "authentication_error"
+
+class TestAPITimeoutError:
+    """Tests for APITimeoutError."""
+
+    def test_message(self) -> None:
+        """Should have timeout message."""
+        error = APITimeoutError()
+        assert "timed out" in error.message
+
+    def test_is_connection_error(self) -> None:
+        """Should be an APIConnectionError."""
+        error = APITimeoutError()
+        assert isinstance(error, APIConnectionError)
+
+
+class TestAPIStatusError:
+    """Tests for APIStatusError."""
+
+    def test_stores_status_code(self) -> None:
+        """Should store status code."""
+        response = _make_response(500)
+        error = APIStatusError("error", response=response)
+        assert error.status_code == 500
+
+    def test_stores_response(self) -> None:
+        """Should store response."""
+        response = _make_response(500)
+        error = APIStatusError("error", response=response)
+        assert error.response is response
 
 
 class TestBadRequestError:
     """Tests for BadRequestError."""
 
-    def test_status_is_400(self) -> None:
-        """Should have 400 status."""
-        error = BadRequestError()
-        assert error.status == 400
+    def test_is_status_error(self) -> None:
+        """Should be an APIStatusError."""
+        response = _make_response(400)
+        error = BadRequestError("bad request", response=response)
+        assert isinstance(error, APIStatusError)
+        assert error.status_code == 400
+
+
+class TestAuthenticationError:
+    """Tests for AuthenticationError."""
+
+    def test_is_status_error(self) -> None:
+        """Should be an APIStatusError."""
+        response = _make_response(401)
+        error = AuthenticationError("auth failed", response=response)
+        assert isinstance(error, APIStatusError)
+        assert error.status_code == 401
+
+
+class TestPermissionDeniedError:
+    """Tests for PermissionDeniedError."""
+
+    def test_is_status_error(self) -> None:
+        """Should be an APIStatusError."""
+        response = _make_response(403)
+        error = PermissionDeniedError("forbidden", response=response)
+        assert isinstance(error, APIStatusError)
+        assert error.status_code == 403
 
 
 class TestNotFoundError:
     """Tests for NotFoundError."""
 
-    def test_status_is_404(self) -> None:
-        """Should have 404 status."""
-        error = NotFoundError()
-        assert error.status == 404
+    def test_is_status_error(self) -> None:
+        """Should be an APIStatusError."""
+        response = _make_response(404)
+        error = NotFoundError("not found", response=response)
+        assert isinstance(error, APIStatusError)
+        assert error.status_code == 404
 
 
 class TestRateLimitError:
     """Tests for RateLimitError."""
 
-    def test_status_is_429(self) -> None:
-        """Should have 429 status."""
-        error = RateLimitError()
-        assert error.status == 429
+    def test_is_status_error(self) -> None:
+        """Should be an APIStatusError."""
+        response = _make_response(429)
+        error = RateLimitError("rate limited", response=response)
+        assert isinstance(error, APIStatusError)
+        assert error.status_code == 429
 
 
 class TestInternalServerError:
     """Tests for InternalServerError."""
 
-    def test_status_is_500(self) -> None:
-        """Should have 500 status."""
-        error = InternalServerError()
-        assert error.status == 500
+    def test_is_status_error(self) -> None:
+        """Should be an APIStatusError."""
+        response = _make_response(500)
+        error = InternalServerError("server error", response=response)
+        assert isinstance(error, APIStatusError)
+        assert error.status_code == 500
 
 
 class TestWebSocketError:
     """Tests for WebSocketError."""
 
+    def test_is_polymarket_error(self) -> None:
+        """Should be a PolymarketUSError."""
+        error = WebSocketError("test")
+        assert isinstance(error, PolymarketUSError)
+
     def test_stores_request_id(self) -> None:
         """Should store request_id."""
-        error = WebSocketError("error", "req-123")
+        error = WebSocketError("test", request_id="req-123")
         assert error.request_id == "req-123"
-
-    def test_request_id_optional(self) -> None:
-        """Should work without request_id."""
-        error = WebSocketError("error")
-        assert error.request_id is None

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,142 @@
+"""Tests for events endpoints."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from polymarket_us import PolymarketUS
+
+
+class TestEventsList:
+    """Tests for events.list()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @patch.object(httpx.Client, "request")
+    def test_list_events(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should list events."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"events": [{"id": 1}, {"id": 2}]}'
+        mock_response.json.return_value = {
+            "events": [
+                {"id": 1, "slug": "event-1", "title": "Event 1"},
+                {"id": 2, "slug": "event-2", "title": "Event 2"},
+            ]
+        }
+        mock_request.return_value = mock_response
+
+        response = client.events.list()
+
+        assert "events" in response
+        assert len(response["events"]) == 2
+
+    @patch.object(httpx.Client, "request")
+    def test_passes_query_params(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should pass query params."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"events": []}'
+        mock_response.json.return_value = {"events": []}
+        mock_request.return_value = mock_response
+
+        client.events.list({"limit": 10, "active": True})
+
+        call_kwargs = mock_request.call_args.kwargs
+        params = call_kwargs.get("params", [])
+        param_dict = dict(params)
+        assert param_dict.get("limit") == "10"
+        assert param_dict.get("active") == "true"
+
+    @patch.object(httpx.Client, "request")
+    def test_calls_gateway_url(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should call gateway URL."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"events": []}'
+        mock_response.json.return_value = {"events": []}
+        mock_request.return_value = mock_response
+
+        client.events.list()
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "gateway.polymarket.us" in url
+        assert "/v1/events" in url
+
+
+class TestEventsRetrieve:
+    """Tests for events.retrieve()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @patch.object(httpx.Client, "request")
+    def test_retrieve_event_by_id(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should retrieve event by ID."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"event": {"id": 123}}'
+        mock_response.json.return_value = {"event": {"id": 123, "title": "Test Event"}}
+        mock_request.return_value = mock_response
+
+        response = client.events.retrieve(123)
+
+        assert "event" in response
+        assert response["event"]["id"] == 123
+
+    @patch.object(httpx.Client, "request")
+    def test_uses_correct_path(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should use correct path."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"event": {}}'
+        mock_response.json.return_value = {"event": {}}
+        mock_request.return_value = mock_response
+
+        client.events.retrieve(456)
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "/v1/events/456" in url
+
+
+class TestEventsRetrieveBySlug:
+    """Tests for events.retrieve_by_slug()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @patch.object(httpx.Client, "request")
+    def test_retrieve_event_by_slug(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should retrieve event by slug."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"event": {"slug": "super-bowl"}}'
+        mock_response.json.return_value = {"event": {"slug": "super-bowl", "title": "Super Bowl"}}
+        mock_request.return_value = mock_response
+
+        response = client.events.retrieve_by_slug("super-bowl")
+
+        assert "event" in response
+        assert response["event"]["slug"] == "super-bowl"
+
+    @patch.object(httpx.Client, "request")
+    def test_uses_correct_path(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should use correct path."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"event": {}}'
+        mock_response.json.return_value = {"event": {}}
+        mock_request.return_value = mock_response
+
+        client.events.retrieve_by_slug("my-event")
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "/v1/events/slug/my-event" in url

--- a/tests/test_http_errors.py
+++ b/tests/test_http_errors.py
@@ -26,9 +26,7 @@ class TestHTTPErrors:
         """Create a client."""
         return PolymarketUS()
 
-    def _make_mock_response(
-        self, status_code: int, message: str, reason: str
-    ) -> MagicMock:
+    def _make_mock_response(self, status_code: int, message: str, reason: str) -> MagicMock:
         """Create a mock response."""
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.is_success = False
@@ -40,9 +38,7 @@ class TestHTTPErrors:
         return mock_response
 
     @patch.object(httpx.Client, "request")
-    def test_400_raises_bad_request(
-        self, mock_request: MagicMock, client: PolymarketUS
-    ) -> None:
+    def test_400_raises_bad_request(self, mock_request: MagicMock, client: PolymarketUS) -> None:
         """400 should raise BadRequestError."""
         mock_request.return_value = self._make_mock_response(
             400, "Invalid parameters", "Bad Request"
@@ -59,9 +55,7 @@ class TestHTTPErrors:
         self, mock_request: MagicMock, client: PolymarketUS
     ) -> None:
         """401 should raise AuthenticationError."""
-        mock_request.return_value = self._make_mock_response(
-            401, "Invalid API key", "Unauthorized"
-        )
+        mock_request.return_value = self._make_mock_response(401, "Invalid API key", "Unauthorized")
 
         with pytest.raises(AuthenticationError) as exc_info:
             client.events.list()
@@ -81,13 +75,9 @@ class TestHTTPErrors:
         assert exc_info.value.status_code == 403
 
     @patch.object(httpx.Client, "request")
-    def test_404_raises_not_found(
-        self, mock_request: MagicMock, client: PolymarketUS
-    ) -> None:
+    def test_404_raises_not_found(self, mock_request: MagicMock, client: PolymarketUS) -> None:
         """404 should raise NotFoundError."""
-        mock_request.return_value = self._make_mock_response(
-            404, "Event not found", "Not Found"
-        )
+        mock_request.return_value = self._make_mock_response(404, "Event not found", "Not Found")
 
         with pytest.raises(NotFoundError) as exc_info:
             client.events.retrieve(99999)
@@ -95,9 +85,7 @@ class TestHTTPErrors:
         assert exc_info.value.status_code == 404
 
     @patch.object(httpx.Client, "request")
-    def test_429_raises_rate_limit(
-        self, mock_request: MagicMock, client: PolymarketUS
-    ) -> None:
+    def test_429_raises_rate_limit(self, mock_request: MagicMock, client: PolymarketUS) -> None:
         """429 should raise RateLimitError."""
         mock_request.return_value = self._make_mock_response(
             429, "Too many requests", "Too Many Requests"

--- a/tests/test_http_errors.py
+++ b/tests/test_http_errors.py
@@ -6,110 +6,156 @@ import httpx
 import pytest
 
 from polymarket_us import (
+    APIConnectionError,
+    APITimeoutError,
     AuthenticationError,
     BadRequestError,
     InternalServerError,
     NotFoundError,
+    PermissionDeniedError,
     PolymarketUS,
     RateLimitError,
 )
 
 
 class TestHTTPErrors:
-    """Tests for HTTP error handling."""
+    """Tests for HTTP error responses."""
 
     @pytest.fixture
     def client(self) -> PolymarketUS:
         """Create a client."""
         return PolymarketUS()
 
-    @patch.object(httpx.Client, "request")
-    def test_400_raises_bad_request(self, mock_request: MagicMock, client: PolymarketUS) -> None:
-        """400 should raise BadRequestError."""
-        mock_response = MagicMock()
+    def _make_mock_response(
+        self, status_code: int, message: str, reason: str
+    ) -> MagicMock:
+        """Create a mock response."""
+        mock_response = MagicMock(spec=httpx.Response)
         mock_response.is_success = False
-        mock_response.status_code = 400
-        mock_response.text = '{"message": "Invalid parameters"}'
-        mock_response.json.return_value = {"message": "Invalid parameters"}
-        mock_response.reason_phrase = "Bad Request"
-        mock_request.return_value = mock_response
+        mock_response.status_code = status_code
+        mock_response.text = f'{{"message": "{message}"}}'
+        mock_response.json.return_value = {"message": message}
+        mock_response.reason_phrase = reason
+        mock_response.request = httpx.Request("GET", "http://test")
+        return mock_response
+
+    @patch.object(httpx.Client, "request")
+    def test_400_raises_bad_request(
+        self, mock_request: MagicMock, client: PolymarketUS
+    ) -> None:
+        """400 should raise BadRequestError."""
+        mock_request.return_value = self._make_mock_response(
+            400, "Invalid parameters", "Bad Request"
+        )
 
         with pytest.raises(BadRequestError) as exc_info:
             client.events.list()
 
         assert "Invalid parameters" in str(exc_info.value)
+        assert exc_info.value.status_code == 400
 
     @patch.object(httpx.Client, "request")
     def test_401_raises_authentication_error(
         self, mock_request: MagicMock, client: PolymarketUS
     ) -> None:
         """401 should raise AuthenticationError."""
-        mock_response = MagicMock()
-        mock_response.is_success = False
-        mock_response.status_code = 401
-        mock_response.text = '{"message": "Invalid API key"}'
-        mock_response.json.return_value = {"message": "Invalid API key"}
-        mock_response.reason_phrase = "Unauthorized"
-        mock_request.return_value = mock_response
+        mock_request.return_value = self._make_mock_response(
+            401, "Invalid API key", "Unauthorized"
+        )
 
-        with pytest.raises(AuthenticationError):
+        with pytest.raises(AuthenticationError) as exc_info:
             client.events.list()
 
-    @patch.object(httpx.Client, "request")
-    def test_404_raises_not_found(self, mock_request: MagicMock, client: PolymarketUS) -> None:
-        """404 should raise NotFoundError."""
-        mock_response = MagicMock()
-        mock_response.is_success = False
-        mock_response.status_code = 404
-        mock_response.text = '{"message": "Event not found"}'
-        mock_response.json.return_value = {"message": "Event not found"}
-        mock_response.reason_phrase = "Not Found"
-        mock_request.return_value = mock_response
+        assert exc_info.value.status_code == 401
 
-        with pytest.raises(NotFoundError):
+    @patch.object(httpx.Client, "request")
+    def test_403_raises_permission_denied(
+        self, mock_request: MagicMock, client: PolymarketUS
+    ) -> None:
+        """403 should raise PermissionDeniedError."""
+        mock_request.return_value = self._make_mock_response(403, "Forbidden", "Forbidden")
+
+        with pytest.raises(PermissionDeniedError) as exc_info:
+            client.events.list()
+
+        assert exc_info.value.status_code == 403
+
+    @patch.object(httpx.Client, "request")
+    def test_404_raises_not_found(
+        self, mock_request: MagicMock, client: PolymarketUS
+    ) -> None:
+        """404 should raise NotFoundError."""
+        mock_request.return_value = self._make_mock_response(
+            404, "Event not found", "Not Found"
+        )
+
+        with pytest.raises(NotFoundError) as exc_info:
             client.events.retrieve(99999)
 
-    @patch.object(httpx.Client, "request")
-    def test_429_raises_rate_limit(self, mock_request: MagicMock, client: PolymarketUS) -> None:
-        """429 should raise RateLimitError."""
-        mock_response = MagicMock()
-        mock_response.is_success = False
-        mock_response.status_code = 429
-        mock_response.text = '{"message": "Too many requests"}'
-        mock_response.json.return_value = {"message": "Too many requests"}
-        mock_response.reason_phrase = "Too Many Requests"
-        mock_request.return_value = mock_response
+        assert exc_info.value.status_code == 404
 
-        with pytest.raises(RateLimitError):
+    @patch.object(httpx.Client, "request")
+    def test_429_raises_rate_limit(
+        self, mock_request: MagicMock, client: PolymarketUS
+    ) -> None:
+        """429 should raise RateLimitError."""
+        mock_request.return_value = self._make_mock_response(
+            429, "Too many requests", "Too Many Requests"
+        )
+
+        with pytest.raises(RateLimitError) as exc_info:
             client.events.list()
+
+        assert exc_info.value.status_code == 429
 
     @patch.object(httpx.Client, "request")
     def test_500_raises_internal_server_error(
         self, mock_request: MagicMock, client: PolymarketUS
     ) -> None:
         """500 should raise InternalServerError."""
-        mock_response = MagicMock()
-        mock_response.is_success = False
-        mock_response.status_code = 500
-        mock_response.text = '{"message": "Internal error"}'
-        mock_response.json.return_value = {"message": "Internal error"}
-        mock_response.reason_phrase = "Internal Server Error"
-        mock_request.return_value = mock_response
+        mock_request.return_value = self._make_mock_response(
+            500, "Internal error", "Internal Server Error"
+        )
 
-        with pytest.raises(InternalServerError):
+        with pytest.raises(InternalServerError) as exc_info:
             client.events.list()
+
+        assert exc_info.value.status_code == 500
 
     @patch.object(httpx.Client, "request")
     def test_502_raises_internal_server_error(
         self, mock_request: MagicMock, client: PolymarketUS
     ) -> None:
         """502 should raise InternalServerError."""
-        mock_response = MagicMock()
+        mock_response = MagicMock(spec=httpx.Response)
         mock_response.is_success = False
         mock_response.status_code = 502
         mock_response.text = ""
         mock_response.reason_phrase = "Bad Gateway"
+        mock_response.request = httpx.Request("GET", "http://test")
         mock_request.return_value = mock_response
 
-        with pytest.raises(InternalServerError):
+        with pytest.raises(InternalServerError) as exc_info:
+            client.events.list()
+
+        assert exc_info.value.status_code == 502
+
+    @patch.object(httpx.Client, "request")
+    def test_timeout_raises_timeout_error(
+        self, mock_request: MagicMock, client: PolymarketUS
+    ) -> None:
+        """Timeout should raise APITimeoutError."""
+        mock_request.side_effect = httpx.TimeoutException("Connection timed out")
+
+        with pytest.raises(APITimeoutError):
+            client.events.list()
+
+    @patch.object(httpx.Client, "request")
+    def test_connection_error_raises_connection_error(
+        self, mock_request: MagicMock, client: PolymarketUS
+    ) -> None:
+        """Connection error should raise APIConnectionError."""
+        mock_request.side_effect = httpx.ConnectError("Failed to connect")
+
+        with pytest.raises(APIConnectionError):
             client.events.list()

--- a/tests/test_markets.py
+++ b/tests/test_markets.py
@@ -53,9 +53,7 @@ class TestMarketsRetrieve:
         assert response["market"]["id"] == 123
 
     @patch.object(httpx.Client, "request")
-    def test_uses_correct_path_with_id(
-        self, mock_request: MagicMock, client: PolymarketUS
-    ) -> None:
+    def test_uses_correct_path_with_id(self, mock_request: MagicMock, client: PolymarketUS) -> None:
         """Should use correct path with id."""
         mock_response = MagicMock()
         mock_response.is_success = True

--- a/tests/test_markets.py
+++ b/tests/test_markets.py
@@ -1,0 +1,202 @@
+"""Tests for markets endpoints."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from polymarket_us import PolymarketUS
+
+
+class TestMarketsList:
+    """Tests for markets.list()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @patch.object(httpx.Client, "request")
+    def test_list_markets(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should list markets."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"markets": [{"id": 1}, {"id": 2}]}'
+        mock_response.json.return_value = {
+            "markets": [{"id": 1, "slug": "market-1"}, {"id": 2, "slug": "market-2"}]
+        }
+        mock_request.return_value = mock_response
+
+        response = client.markets.list()
+
+        assert "markets" in response
+        assert len(response["markets"]) == 2
+
+
+class TestMarketsRetrieve:
+    """Tests for markets.retrieve()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @patch.object(httpx.Client, "request")
+    def test_retrieve_market_by_id(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should retrieve market by ID."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"market": {"id": 123}}'
+        mock_response.json.return_value = {"market": {"id": 123, "slug": "btc-100k"}}
+        mock_request.return_value = mock_response
+
+        response = client.markets.retrieve(123)
+
+        assert response["market"]["id"] == 123
+
+    @patch.object(httpx.Client, "request")
+    def test_uses_correct_path_with_id(
+        self, mock_request: MagicMock, client: PolymarketUS
+    ) -> None:
+        """Should use correct path with id."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"market": {}}'
+        mock_response.json.return_value = {"market": {}}
+        mock_request.return_value = mock_response
+
+        client.markets.retrieve(456)
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "/v1/market/id/456" in url
+
+
+class TestMarketsRetrieveBySlug:
+    """Tests for markets.retrieve_by_slug()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @patch.object(httpx.Client, "request")
+    def test_uses_correct_path_with_slug(
+        self, mock_request: MagicMock, client: PolymarketUS
+    ) -> None:
+        """Should use correct path with slug."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"market": {}}'
+        mock_response.json.return_value = {"market": {}}
+        mock_request.return_value = mock_response
+
+        client.markets.retrieve_by_slug("btc-100k")
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "/v1/market/slug/btc-100k" in url
+
+
+class TestMarketsBook:
+    """Tests for markets.book()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @patch.object(httpx.Client, "request")
+    def test_get_order_book(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should get order book."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"marketSlug": "btc-100k", "bids": [], "offers": []}'
+        mock_response.json.return_value = {
+            "marketSlug": "btc-100k",
+            "bids": [{"px": {"value": "0.55", "currency": "USD"}, "qty": "100"}],
+            "offers": [{"px": {"value": "0.56", "currency": "USD"}, "qty": "80"}],
+            "state": "MARKET_STATE_OPEN",
+        }
+        mock_request.return_value = mock_response
+
+        book = client.markets.book("btc-100k")
+
+        assert book["marketSlug"] == "btc-100k"
+        assert "bids" in book
+        assert "offers" in book
+
+    @patch.object(httpx.Client, "request")
+    def test_uses_correct_path(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should use correct path."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"bids": [], "offers": []}'
+        mock_response.json.return_value = {"bids": [], "offers": []}
+        mock_request.return_value = mock_response
+
+        client.markets.book("test-market")
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "/v1/markets/test-market/book" in url
+
+
+class TestMarketsBBO:
+    """Tests for markets.bbo()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @patch.object(httpx.Client, "request")
+    def test_get_best_bid_offer(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should get best bid/offer."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"marketSlug": "btc-100k"}'
+        mock_response.json.return_value = {
+            "marketSlug": "btc-100k",
+            "bestBid": {"value": "0.55", "currency": "USD"},
+            "bestAsk": {"value": "0.56", "currency": "USD"},
+        }
+        mock_request.return_value = mock_response
+
+        bbo = client.markets.bbo("btc-100k")
+
+        assert "bestBid" in bbo
+        assert "bestAsk" in bbo
+
+    @patch.object(httpx.Client, "request")
+    def test_uses_correct_path(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should use correct path."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = "{}"
+        mock_response.json.return_value = {}
+        mock_request.return_value = mock_response
+
+        client.markets.bbo("test-market")
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "/v1/markets/test-market/bbo" in url
+
+
+class TestMarketsSettlement:
+    """Tests for markets.settlement()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @patch.object(httpx.Client, "request")
+    def test_uses_correct_path(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should use correct path."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = "{}"
+        mock_response.json.return_value = {}
+        mock_request.return_value = mock_response
+
+        client.markets.settlement("settled-market")
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "/v1/markets/settled-market/settlement" in url

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -23,7 +23,7 @@ class TestOrdersAuthenticationRequired:
         with pytest.raises(AuthenticationError):
             client.orders.create(
                 {
-                    "market_slug": "test",
+                    "marketSlug": "test",
                     "intent": "ORDER_INTENT_BUY_LONG",
                 }
             )
@@ -118,7 +118,7 @@ class TestOrdersCreate:
 
         response = auth_client.orders.create(
             {
-                "market_slug": "btc-100k",
+                "marketSlug": "btc-100k",
                 "intent": "ORDER_INTENT_BUY_LONG",
                 "type": "ORDER_TYPE_LIMIT",
                 "price": {"value": "0.55", "currency": "USD"},
@@ -139,7 +139,7 @@ class TestOrdersCreate:
 
         auth_client.orders.create(
             {
-                "market_slug": "test",
+                "marketSlug": "test",
                 "intent": "ORDER_INTENT_BUY_LONG",
             }
         )

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,160 @@
+"""Tests for portfolio and account endpoints."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from polymarket_us import AuthenticationError, PolymarketUS
+
+TEST_SECRET_KEY = "nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A="
+
+
+class TestPortfolioPositions:
+    """Tests for portfolio.positions()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @pytest.fixture
+    def auth_client(self) -> PolymarketUS:
+        return PolymarketUS(key_id="test-key-id", secret_key=TEST_SECRET_KEY)
+
+    def test_requires_authentication(self, client: PolymarketUS) -> None:
+        """Should require authentication."""
+        with pytest.raises(AuthenticationError):
+            client.portfolio.positions()
+
+    @patch.object(httpx.Client, "request")
+    def test_get_positions_with_auth(
+        self, mock_request: MagicMock, auth_client: PolymarketUS
+    ) -> None:
+        """Should get positions with auth."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"positions": {}}'
+        mock_response.json.return_value = {
+            "positions": {
+                "btc-100k": {"netPosition": "100", "cost": {"value": "55", "currency": "USD"}}
+            }
+        }
+        mock_request.return_value = mock_response
+
+        response = auth_client.portfolio.positions()
+
+        assert "positions" in response
+        assert "btc-100k" in response["positions"]
+
+    @patch.object(httpx.Client, "request")
+    def test_uses_correct_path(self, mock_request: MagicMock, auth_client: PolymarketUS) -> None:
+        """Should use correct path."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"positions": {}}'
+        mock_response.json.return_value = {"positions": {}}
+        mock_request.return_value = mock_response
+
+        auth_client.portfolio.positions()
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "/v1/portfolio/positions" in url
+
+
+class TestPortfolioActivities:
+    """Tests for portfolio.activities()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @pytest.fixture
+    def auth_client(self) -> PolymarketUS:
+        return PolymarketUS(key_id="test-key-id", secret_key=TEST_SECRET_KEY)
+
+    def test_requires_authentication(self, client: PolymarketUS) -> None:
+        """Should require authentication."""
+        with pytest.raises(AuthenticationError):
+            client.portfolio.activities()
+
+    @patch.object(httpx.Client, "request")
+    def test_get_activities_with_auth(
+        self, mock_request: MagicMock, auth_client: PolymarketUS
+    ) -> None:
+        """Should get activities with auth."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"activities": []}'
+        mock_response.json.return_value = {"activities": [{"type": "ACTIVITY_TYPE_TRADE"}]}
+        mock_request.return_value = mock_response
+
+        response = auth_client.portfolio.activities()
+
+        assert "activities" in response
+        assert len(response["activities"]) == 1
+
+    @patch.object(httpx.Client, "request")
+    def test_uses_correct_path(self, mock_request: MagicMock, auth_client: PolymarketUS) -> None:
+        """Should use correct path."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"activities": []}'
+        mock_response.json.return_value = {"activities": []}
+        mock_request.return_value = mock_response
+
+        auth_client.portfolio.activities()
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "/v1/portfolio/activities" in url
+
+
+class TestAccountBalances:
+    """Tests for account.balances()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @pytest.fixture
+    def auth_client(self) -> PolymarketUS:
+        return PolymarketUS(key_id="test-key-id", secret_key=TEST_SECRET_KEY)
+
+    def test_requires_authentication(self, client: PolymarketUS) -> None:
+        """Should require authentication."""
+        with pytest.raises(AuthenticationError):
+            client.account.balances()
+
+    @patch.object(httpx.Client, "request")
+    def test_get_balances_with_auth(
+        self, mock_request: MagicMock, auth_client: PolymarketUS
+    ) -> None:
+        """Should get balances with auth."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"balances": []}'
+        mock_response.json.return_value = {
+            "balances": [{"currentBalance": 1000, "currency": "USD", "buyingPower": 800}]
+        }
+        mock_request.return_value = mock_response
+
+        response = auth_client.account.balances()
+
+        assert "balances" in response
+        assert response["balances"][0]["currentBalance"] == 1000
+
+    @patch.object(httpx.Client, "request")
+    def test_uses_correct_path(self, mock_request: MagicMock, auth_client: PolymarketUS) -> None:
+        """Should use correct path."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"balances": []}'
+        mock_response.json.return_value = {"balances": []}
+        mock_request.return_value = mock_response
+
+        auth_client.account.balances()
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "/v1/account/balances" in url

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,79 @@
+"""Tests for search endpoints."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from polymarket_us import PolymarketUS
+
+
+class TestSearchQuery:
+    """Tests for search.query()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @patch.object(httpx.Client, "request")
+    def test_search_without_params(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should search without params."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"events": []}'
+        mock_response.json.return_value = {"events": []}
+        mock_request.return_value = mock_response
+
+        response = client.search.query()
+
+        assert "events" in response
+        mock_request.assert_called_once()
+
+    @patch.object(httpx.Client, "request")
+    def test_passes_search_query_params(
+        self, mock_request: MagicMock, client: PolymarketUS
+    ) -> None:
+        """Should pass search query params."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"events": []}'
+        mock_response.json.return_value = {"events": []}
+        mock_request.return_value = mock_response
+
+        client.search.query({"query": "bitcoin", "limit": 5})
+
+        call_kwargs = mock_request.call_args.kwargs
+        params = call_kwargs.get("params", [])
+        param_dict = dict(params)
+        assert param_dict.get("query") == "bitcoin"
+        assert param_dict.get("limit") == "5"
+
+    @patch.object(httpx.Client, "request")
+    def test_uses_correct_path(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should use correct path."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"events": []}'
+        mock_response.json.return_value = {"events": []}
+        mock_request.return_value = mock_response
+
+        client.search.query()
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "/v1/search" in url
+
+    @patch.object(httpx.Client, "request")
+    def test_calls_gateway_url(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should call gateway URL."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"events": []}'
+        mock_response.json.return_value = {"events": []}
+        mock_request.return_value = mock_response
+
+        client.search.query()
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "gateway.polymarket.us" in url

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1,0 +1,99 @@
+"""Tests for series endpoints."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from polymarket_us import PolymarketUS
+
+
+class TestSeriesList:
+    """Tests for series.list()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @patch.object(httpx.Client, "request")
+    def test_list_series(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should list series."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"series": []}'
+        mock_response.json.return_value = {
+            "series": [{"id": 1, "name": "NBA Finals"}, {"id": 2, "name": "World Series"}]
+        }
+        mock_request.return_value = mock_response
+
+        response = client.series.list()
+
+        assert "series" in response
+        mock_request.assert_called_once()
+
+    @patch.object(httpx.Client, "request")
+    def test_passes_query_params(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should pass query params."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"series": []}'
+        mock_response.json.return_value = {"series": []}
+        mock_request.return_value = mock_response
+
+        client.series.list({"limit": 10})
+
+        call_kwargs = mock_request.call_args.kwargs
+        params = call_kwargs.get("params", [])
+        param_dict = dict(params)
+        assert param_dict.get("limit") == "10"
+
+    @patch.object(httpx.Client, "request")
+    def test_uses_correct_path(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should use correct path."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"series": []}'
+        mock_response.json.return_value = {"series": []}
+        mock_request.return_value = mock_response
+
+        client.series.list()
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "/v1/series" in url
+
+
+class TestSeriesRetrieve:
+    """Tests for series.retrieve()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @patch.object(httpx.Client, "request")
+    def test_retrieve_series_by_id(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should retrieve series by ID."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"series": {}}'
+        mock_response.json.return_value = {"series": {"id": 123, "name": "Test Series"}}
+        mock_request.return_value = mock_response
+
+        response = client.series.retrieve(123)
+
+        assert "series" in response
+
+    @patch.object(httpx.Client, "request")
+    def test_uses_correct_path(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should use correct path."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"series": {}}'
+        mock_response.json.return_value = {"series": {}}
+        mock_request.return_value = mock_response
+
+        client.series.retrieve(456)
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "/v1/series/id/456" in url

--- a/tests/test_sports.py
+++ b/tests/test_sports.py
@@ -1,0 +1,108 @@
+"""Tests for sports endpoints."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from polymarket_us import PolymarketUS
+
+
+class TestSportsList:
+    """Tests for sports.list()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @patch.object(httpx.Client, "request")
+    def test_list_sports(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should list sports."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"sports": []}'
+        mock_response.json.return_value = {
+            "sports": [
+                {"id": "basketball", "name": "Basketball", "slug": "basketball"},
+                {"id": "baseball", "name": "Baseball", "slug": "baseball"},
+            ]
+        }
+        mock_request.return_value = mock_response
+
+        response = client.sports.list()
+
+        assert "sports" in response
+        mock_request.assert_called_once()
+
+    @patch.object(httpx.Client, "request")
+    def test_uses_correct_path(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should use correct path."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"sports": []}'
+        mock_response.json.return_value = {"sports": []}
+        mock_request.return_value = mock_response
+
+        client.sports.list()
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "/v1/sports" in url
+
+
+class TestSportsTeams:
+    """Tests for sports.teams()."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS()
+
+    @patch.object(httpx.Client, "request")
+    def test_list_teams(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should list teams."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"teams": {}}'
+        mock_response.json.return_value = {
+            "teams": {
+                "lakers": {"id": 1, "name": "Lakers"},
+                "celtics": {"id": 2, "name": "Celtics"},
+            }
+        }
+        mock_request.return_value = mock_response
+
+        response = client.sports.teams()
+
+        assert "teams" in response
+
+    @patch.object(httpx.Client, "request")
+    def test_passes_query_params(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should pass query params."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"teams": {}}'
+        mock_response.json.return_value = {"teams": {}}
+        mock_request.return_value = mock_response
+
+        client.sports.teams({"provider": "espn", "league": "nba"})
+
+        call_kwargs = mock_request.call_args.kwargs
+        params = call_kwargs.get("params", [])
+        param_dict = dict(params)
+        assert param_dict.get("provider") == "espn"
+        assert param_dict.get("league") == "nba"
+
+    @patch.object(httpx.Client, "request")
+    def test_uses_correct_path(self, mock_request: MagicMock, client: PolymarketUS) -> None:
+        """Should use correct path."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.text = '{"teams": {}}'
+        mock_response.json.return_value = {"teams": {}}
+        mock_request.return_value = mock_response
+
+        client.sports.teams()
+
+        call_args = mock_request.call_args
+        url = call_args.args[1] if len(call_args.args) > 1 else call_args.kwargs.get("url")
+        assert "/v1/sports/teams/provider" in url

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,177 @@
+"""Tests for WebSocket functionality."""
+
+import pytest
+
+from polymarket_us import AuthenticationError, PolymarketUS
+from polymarket_us.websocket import MarketsWebSocket, PrivateWebSocket
+
+TEST_SECRET_KEY = "nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A="
+
+
+class TestWebSocketFactory:
+    """Tests for WebSocket factory."""
+
+    def test_has_ws_factory_on_client(self) -> None:
+        """Should have ws factory on client."""
+        client = PolymarketUS(key_id="test-key", secret_key=TEST_SECRET_KEY)
+        assert client.ws is not None
+
+    def test_creates_private_websocket_instance(self) -> None:
+        """Should create private WebSocket instance."""
+        client = PolymarketUS(key_id="test-key", secret_key=TEST_SECRET_KEY)
+        private_ws = client.ws.private()
+        assert isinstance(private_ws, PrivateWebSocket)
+
+    def test_creates_markets_websocket_instance(self) -> None:
+        """Should create markets WebSocket instance."""
+        client = PolymarketUS(key_id="test-key", secret_key=TEST_SECRET_KEY)
+        markets_ws = client.ws.markets()
+        assert isinstance(markets_ws, MarketsWebSocket)
+
+    def test_throws_without_credentials_for_private_websocket(self) -> None:
+        """Should throw without credentials for private WebSocket."""
+        client = PolymarketUS()
+        with pytest.raises(AuthenticationError, match="credentials required"):
+            client.ws.private()
+
+    def test_throws_without_credentials_for_markets_websocket(self) -> None:
+        """Should throw without credentials for markets WebSocket."""
+        client = PolymarketUS()
+        with pytest.raises(AuthenticationError, match="credentials required"):
+            client.ws.markets()
+
+
+class TestPrivateWebSocket:
+    """Tests for PrivateWebSocket."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS(key_id="test-key", secret_key=TEST_SECRET_KEY)
+
+    def test_has_connect_method(self, client: PolymarketUS) -> None:
+        """Should have connect method."""
+        ws = client.ws.private()
+        assert hasattr(ws, "connect")
+        assert callable(ws.connect)
+
+    def test_has_close_method(self, client: PolymarketUS) -> None:
+        """Should have close method."""
+        ws = client.ws.private()
+        assert hasattr(ws, "close")
+        assert callable(ws.close)
+
+    def test_has_subscribe_methods(self, client: PolymarketUS) -> None:
+        """Should have subscribe methods."""
+        ws = client.ws.private()
+        assert hasattr(ws, "subscribe_orders")
+        assert hasattr(ws, "subscribe_positions")
+        assert hasattr(ws, "subscribe_account_balance")
+        assert callable(ws.subscribe_orders)
+        assert callable(ws.subscribe_positions)
+        assert callable(ws.subscribe_account_balance)
+
+    def test_has_unsubscribe_method(self, client: PolymarketUS) -> None:
+        """Should have unsubscribe method."""
+        ws = client.ws.private()
+        assert hasattr(ws, "unsubscribe")
+        assert callable(ws.unsubscribe)
+
+    def test_has_on_method_for_event_listeners(self, client: PolymarketUS) -> None:
+        """Should have on method for event listeners."""
+        ws = client.ws.private()
+        assert hasattr(ws, "on")
+        assert callable(ws.on)
+
+    def test_has_off_method_to_remove_listeners(self, client: PolymarketUS) -> None:
+        """Should have off method to remove listeners."""
+        ws = client.ws.private()
+        assert hasattr(ws, "off")
+        assert callable(ws.off)
+
+    def test_has_is_connected_property(self, client: PolymarketUS) -> None:
+        """Should have is_connected property."""
+        ws = client.ws.private()
+        assert hasattr(ws, "is_connected")
+        assert ws.is_connected is False
+
+    def test_accepts_event_listeners(self, client: PolymarketUS) -> None:
+        """Should accept event listeners."""
+        ws = client.ws.private()
+
+        def on_order_snapshot(data: object) -> None:
+            pass
+
+        def on_order_update(data: object) -> None:
+            pass
+
+        def on_error(error: object) -> None:
+            pass
+
+        ws.on("order_snapshot", on_order_snapshot)
+        ws.on("order_update", on_order_update)
+        ws.on("error", on_error)
+
+
+class TestMarketsWebSocket:
+    """Tests for MarketsWebSocket."""
+
+    @pytest.fixture
+    def client(self) -> PolymarketUS:
+        return PolymarketUS(key_id="test-key", secret_key=TEST_SECRET_KEY)
+
+    def test_has_connect_method(self, client: PolymarketUS) -> None:
+        """Should have connect method."""
+        ws = client.ws.markets()
+        assert hasattr(ws, "connect")
+        assert callable(ws.connect)
+
+    def test_has_close_method(self, client: PolymarketUS) -> None:
+        """Should have close method."""
+        ws = client.ws.markets()
+        assert hasattr(ws, "close")
+        assert callable(ws.close)
+
+    def test_has_subscribe_methods(self, client: PolymarketUS) -> None:
+        """Should have subscribe methods."""
+        ws = client.ws.markets()
+        assert hasattr(ws, "subscribe_market_data")
+        assert hasattr(ws, "subscribe_market_data_lite")
+        assert hasattr(ws, "subscribe_trades")
+        assert callable(ws.subscribe_market_data)
+        assert callable(ws.subscribe_market_data_lite)
+        assert callable(ws.subscribe_trades)
+
+    def test_has_unsubscribe_method(self, client: PolymarketUS) -> None:
+        """Should have unsubscribe method."""
+        ws = client.ws.markets()
+        assert hasattr(ws, "unsubscribe")
+        assert callable(ws.unsubscribe)
+
+    def test_has_on_method_for_event_listeners(self, client: PolymarketUS) -> None:
+        """Should have on method for event listeners."""
+        ws = client.ws.markets()
+        assert hasattr(ws, "on")
+        assert callable(ws.on)
+
+    def test_has_is_connected_property(self, client: PolymarketUS) -> None:
+        """Should have is_connected property."""
+        ws = client.ws.markets()
+        assert hasattr(ws, "is_connected")
+        assert ws.is_connected is False
+
+    def test_accepts_event_listeners(self, client: PolymarketUS) -> None:
+        """Should accept event listeners."""
+        ws = client.ws.markets()
+
+        def on_market_data(data: object) -> None:
+            pass
+
+        def on_trade(data: object) -> None:
+            pass
+
+        def on_error(error: object) -> None:
+            pass
+
+        ws.on("market_data", on_market_data)
+        ws.on("trade", on_trade)
+        ws.on("error", on_error)


### PR DESCRIPTION
- Fix unsafe access to e.request on TimeoutException/ConnectError
- Fix ruff C416 lint warnings in test files (use dict() instead of comprehension)
- Add comprehensive test coverage for events, markets, portfolio, search, series, sports, websocket
- Update README examples to use camelCase keys matching API spec
- Add APIConnectionError and APITimeoutError to error handling examples

## Changes

<!-- What does this PR do? -->

## Testing

<!-- How was this tested? -->

## Checklist

- [ ] Tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Types check (`mypy polymarket_us`)
