### PR TITLE
feat: add auto-pagination iterators for list endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,29 @@ async def main():
 asyncio.run(main())
 ```
 
+## Pagination
+
+List endpoints expose `iterate()` helpers that transparently page through all
+results. Offset-paginated resources (`events`, `markets`, `series`) and the
+cursor-paginated activity feed are both supported:
+
+```python
+# Offset-paginated resources
+for market in client.markets.iterate({"active": True}):
+    print(market["slug"])
+
+# Cursor-paginated activity history (authenticated)
+for activity in client.portfolio.iterate_activities():
+    print(activity["type"])
+```
+
+Async clients return async iterators:
+
+```python
+async for market in async_client.markets.iterate({"active": True}):
+    print(market["slug"])
+```
+
 ## Authentication
 
 Polymarket US uses Ed25519 signature authentication. Generate API keys at [polymarket.us/developer](https://polymarket.us/developer).

--- a/polymarket_us/pagination.py
+++ b/polymarket_us/pagination.py
@@ -22,6 +22,7 @@ def paginate_offset(
     page_size: int = DEFAULT_PAGE_SIZE,
 ) -> Iterator[Any]:
     """Yield items across offset-paginated pages until a short page is returned."""
+    page_size = max(1, page_size)
     offset = 0
     while True:
         page = fetch(offset, page_size)
@@ -55,6 +56,7 @@ async def paginate_offset_async(
     page_size: int = DEFAULT_PAGE_SIZE,
 ) -> AsyncIterator[Any]:
     """Async variant of :func:`paginate_offset`."""
+    page_size = max(1, page_size)
     offset = 0
     while True:
         page = await fetch(offset, page_size)

--- a/polymarket_us/pagination.py
+++ b/polymarket_us/pagination.py
@@ -1,0 +1,84 @@
+"""Auto-pagination helpers for list endpoints.
+
+The API uses two pagination styles:
+
+- cursor-based (``next_cursor`` / ``eof``) for activities and positions, and
+- offset-based (bare array responses) for events, markets, series, and tags.
+
+These helpers transparently walk all pages and yield individual items.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from typing import Any
+
+DEFAULT_PAGE_SIZE = 100
+
+
+def paginate_offset(
+    fetch: Callable[[int, int], dict[str, Any]],
+    items_key: str,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[Any]:
+    """Yield items across offset-paginated pages until a short page is returned."""
+    offset = 0
+    while True:
+        page = fetch(offset, page_size)
+        items = page.get(items_key) or []
+        yield from items
+        if len(items) < page_size:
+            return
+        offset += page_size
+
+
+def paginate_cursor(
+    fetch: Callable[[str | None], dict[str, Any]],
+    items_key: str,
+) -> Iterator[Any]:
+    """Yield items across cursor-paginated pages until ``eof`` or no next cursor."""
+    cursor: str | None = None
+    while True:
+        page = fetch(cursor)
+        items = page.get(items_key) or []
+        yield from items
+        if page.get("eof"):
+            return
+        cursor = page.get("nextCursor")
+        if not cursor:
+            return
+
+
+async def paginate_offset_async(
+    fetch: Callable[[int, int], Awaitable[dict[str, Any]]],
+    items_key: str,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> AsyncIterator[Any]:
+    """Async variant of :func:`paginate_offset`."""
+    offset = 0
+    while True:
+        page = await fetch(offset, page_size)
+        items = page.get(items_key) or []
+        for item in items:
+            yield item
+        if len(items) < page_size:
+            return
+        offset += page_size
+
+
+async def paginate_cursor_async(
+    fetch: Callable[[str | None], Awaitable[dict[str, Any]]],
+    items_key: str,
+) -> AsyncIterator[Any]:
+    """Async variant of :func:`paginate_cursor`."""
+    cursor: str | None = None
+    while True:
+        page = await fetch(cursor)
+        items = page.get(items_key) or []
+        for item in items:
+            yield item
+        if page.get("eof"):
+            return
+        cursor = page.get("nextCursor")
+        if not cursor:
+            return

--- a/polymarket_us/resources/events.py
+++ b/polymarket_us/resources/events.py
@@ -1,7 +1,15 @@
 """Events resource."""
 
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+from polymarket_us.pagination import (
+    DEFAULT_PAGE_SIZE,
+    paginate_offset,
+    paginate_offset_async,
+)
 from polymarket_us.resource import APIResource, AsyncAPIResource
-from polymarket_us.types import EventsListParams, GetEventResponse, GetEventsResponse
+from polymarket_us.types import Event, EventsListParams, GetEventResponse, GetEventsResponse
 
 
 class Events(APIResource):
@@ -10,6 +18,22 @@ class Events(APIResource):
     def list(self, params: EventsListParams | None = None) -> GetEventsResponse:
         """List events with optional filtering."""
         return self._client.get("/v1/events", query=dict(params) if params else None)
+
+    def iterate(
+        self,
+        params: EventsListParams | None = None,
+        *,
+        page_size: int = DEFAULT_PAGE_SIZE,
+    ) -> Iterator[Event]:
+        """Iterate over all events across pages, fetching them lazily."""
+
+        def fetch(offset: int, limit: int) -> dict[str, Any]:
+            query: dict[str, Any] = dict(params) if params else {}
+            query["limit"] = limit
+            query["offset"] = offset
+            return self._client.get("/v1/events", query=query)
+
+        return paginate_offset(fetch, "events", page_size)
 
     def retrieve(self, id: int) -> GetEventResponse:
         """Get an event by ID."""
@@ -26,6 +50,22 @@ class AsyncEvents(AsyncAPIResource):
     async def list(self, params: EventsListParams | None = None) -> GetEventsResponse:
         """List events with optional filtering."""
         return await self._client.get("/v1/events", query=dict(params) if params else None)
+
+    def iterate(
+        self,
+        params: EventsListParams | None = None,
+        *,
+        page_size: int = DEFAULT_PAGE_SIZE,
+    ) -> AsyncIterator[Event]:
+        """Iterate over all events across pages, fetching them lazily."""
+
+        async def fetch(offset: int, limit: int) -> dict[str, Any]:
+            query: dict[str, Any] = dict(params) if params else {}
+            query["limit"] = limit
+            query["offset"] = offset
+            return await self._client.get("/v1/events", query=query)
+
+        return paginate_offset_async(fetch, "events", page_size)
 
     async def retrieve(self, id: int) -> GetEventResponse:
         """Get an event by ID."""

--- a/polymarket_us/resources/markets.py
+++ b/polymarket_us/resources/markets.py
@@ -1,11 +1,20 @@
 """Markets resource."""
 
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+from polymarket_us.pagination import (
+    DEFAULT_PAGE_SIZE,
+    paginate_offset,
+    paginate_offset_async,
+)
 from polymarket_us.resource import APIResource, AsyncAPIResource
 from polymarket_us.types import (
     GetMarketResponse,
     GetMarketsResponse,
     MarketBBO,
     MarketBook,
+    MarketDetail,
     MarketSettlement,
     MarketsListParams,
 )
@@ -17,6 +26,22 @@ class Markets(APIResource):
     def list(self, params: MarketsListParams | None = None) -> GetMarketsResponse:
         """List markets with optional filtering."""
         return self._client.get("/v1/markets", query=dict(params) if params else None)
+
+    def iterate(
+        self,
+        params: MarketsListParams | None = None,
+        *,
+        page_size: int = DEFAULT_PAGE_SIZE,
+    ) -> Iterator[MarketDetail]:
+        """Iterate over all markets across pages, fetching them lazily."""
+
+        def fetch(offset: int, limit: int) -> dict[str, Any]:
+            query: dict[str, Any] = dict(params) if params else {}
+            query["limit"] = limit
+            query["offset"] = offset
+            return self._client.get("/v1/markets", query=query)
+
+        return paginate_offset(fetch, "markets", page_size)
 
     def retrieve(self, id: int) -> GetMarketResponse:
         """Get a market by ID."""
@@ -45,6 +70,22 @@ class AsyncMarkets(AsyncAPIResource):
     async def list(self, params: MarketsListParams | None = None) -> GetMarketsResponse:
         """List markets with optional filtering."""
         return await self._client.get("/v1/markets", query=dict(params) if params else None)
+
+    def iterate(
+        self,
+        params: MarketsListParams | None = None,
+        *,
+        page_size: int = DEFAULT_PAGE_SIZE,
+    ) -> AsyncIterator[MarketDetail]:
+        """Iterate over all markets across pages, fetching them lazily."""
+
+        async def fetch(offset: int, limit: int) -> dict[str, Any]:
+            query: dict[str, Any] = dict(params) if params else {}
+            query["limit"] = limit
+            query["offset"] = offset
+            return await self._client.get("/v1/markets", query=query)
+
+        return paginate_offset_async(fetch, "markets", page_size)
 
     async def retrieve(self, id: int) -> GetMarketResponse:
         """Get a market by ID."""

--- a/polymarket_us/resources/portfolio.py
+++ b/polymarket_us/resources/portfolio.py
@@ -1,7 +1,12 @@
 """Portfolio resource."""
 
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+from polymarket_us.pagination import paginate_cursor, paginate_cursor_async
 from polymarket_us.resource import APIResource, AsyncAPIResource
 from polymarket_us.types import (
+    Activity,
     GetActivitiesParams,
     GetActivitiesResponse,
     GetUserPositionsParams,
@@ -28,6 +33,17 @@ class Portfolio(APIResource):
             authenticated=True,
         )
 
+    def iterate_activities(self, params: GetActivitiesParams | None = None) -> Iterator[Activity]:
+        """Iterate over all activities, following the cursor across pages."""
+
+        def fetch(cursor: str | None) -> dict[str, Any]:
+            query: dict[str, Any] = dict(params) if params else {}
+            if cursor:
+                query["cursor"] = cursor
+            return self._client.get("/v1/portfolio/activities", query=query, authenticated=True)
+
+        return paginate_cursor(fetch, "activities")
+
 
 class AsyncPortfolio(AsyncAPIResource):
     """Portfolio API resource (async, requires authentication)."""
@@ -49,3 +65,18 @@ class AsyncPortfolio(AsyncAPIResource):
             query=dict(params) if params else None,
             authenticated=True,
         )
+
+    def iterate_activities(
+        self, params: GetActivitiesParams | None = None
+    ) -> AsyncIterator[Activity]:
+        """Iterate over all activities, following the cursor across pages."""
+
+        async def fetch(cursor: str | None) -> dict[str, Any]:
+            query: dict[str, Any] = dict(params) if params else {}
+            if cursor:
+                query["cursor"] = cursor
+            return await self._client.get(
+                "/v1/portfolio/activities", query=query, authenticated=True
+            )
+
+        return paginate_cursor_async(fetch, "activities")

--- a/polymarket_us/resources/series.py
+++ b/polymarket_us/resources/series.py
@@ -1,7 +1,22 @@
 """Series resource."""
 
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+from polymarket_us.pagination import (
+    DEFAULT_PAGE_SIZE,
+    paginate_offset,
+    paginate_offset_async,
+)
 from polymarket_us.resource import APIResource, AsyncAPIResource
-from polymarket_us.types import GetSeriesListResponse, GetSeriesResponse, SeriesListParams
+from polymarket_us.types import (
+    GetSeriesListResponse,
+    GetSeriesResponse,
+    SeriesListParams,
+)
+from polymarket_us.types import (
+    Series as SeriesType,
+)
 
 
 class Series(APIResource):
@@ -10,6 +25,22 @@ class Series(APIResource):
     def list(self, params: SeriesListParams | None = None) -> GetSeriesListResponse:
         """List series with optional filtering."""
         return self._client.get("/v1/series", query=dict(params) if params else None)
+
+    def iterate(
+        self,
+        params: SeriesListParams | None = None,
+        *,
+        page_size: int = DEFAULT_PAGE_SIZE,
+    ) -> Iterator[SeriesType]:
+        """Iterate over all series across pages, fetching them lazily."""
+
+        def fetch(offset: int, limit: int) -> dict[str, Any]:
+            query: dict[str, Any] = dict(params) if params else {}
+            query["limit"] = limit
+            query["offset"] = offset
+            return self._client.get("/v1/series", query=query)
+
+        return paginate_offset(fetch, "series", page_size)
 
     def retrieve(self, id: int) -> GetSeriesResponse:
         """Get a series by ID."""
@@ -22,6 +53,22 @@ class AsyncSeries(AsyncAPIResource):
     async def list(self, params: SeriesListParams | None = None) -> GetSeriesListResponse:
         """List series with optional filtering."""
         return await self._client.get("/v1/series", query=dict(params) if params else None)
+
+    def iterate(
+        self,
+        params: SeriesListParams | None = None,
+        *,
+        page_size: int = DEFAULT_PAGE_SIZE,
+    ) -> AsyncIterator[SeriesType]:
+        """Iterate over all series across pages, fetching them lazily."""
+
+        async def fetch(offset: int, limit: int) -> dict[str, Any]:
+            query: dict[str, Any] = dict(params) if params else {}
+            query["limit"] = limit
+            query["offset"] = offset
+            return await self._client.get("/v1/series", query=query)
+
+        return paginate_offset_async(fetch, "series", page_size)
 
     async def retrieve(self, id: int) -> GetSeriesResponse:
         """Get a series by ID."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -64,12 +64,15 @@ class TestCreateAuthHeaders:
 
     def test_handles_64_byte_key(self) -> None:
         """Should handle 64-byte keys (uses first 32 bytes)."""
+        import base64
+
         # 64-byte key (seed + public key), base64 encoded
-        secret_key_64 = "nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A=" * 2
+        seed = base64.b64decode("nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A=")
+        secret_key_64 = base64.b64encode(seed + seed).decode()
         # Should not raise
         headers = create_auth_headers(
             key_id="test",
-            secret_key=secret_key_64[:88],  # 64 bytes in base64
+            secret_key=secret_key_64,
             method="GET",
             path="/v1/test",
         )

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,112 @@
+"""Tests for auto-pagination iterators (offset and cursor)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+from polymarket_us import AsyncPolymarketUS, PolymarketUS
+
+TEST_SECRET_KEY = "nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A="
+
+
+def _json(payload: dict) -> httpx.Response:
+    return httpx.Response(200, json=payload, request=httpx.Request("GET", "http://test"))
+
+
+class TestOffsetPagination:
+    """Offset-based iterators (events, markets, series)."""
+
+    @patch.object(httpx.Client, "request")
+    def test_iterates_until_short_page(self, mock_request: MagicMock) -> None:
+        mock_request.side_effect = [
+            _json({"events": [{"id": 1}, {"id": 2}]}),
+            _json({"events": [{"id": 3}]}),
+        ]
+        client = PolymarketUS()
+
+        events = list(client.events.iterate(page_size=2))
+
+        assert [e["id"] for e in events] == [1, 2, 3]
+        assert mock_request.call_count == 2
+
+    @patch.object(httpx.Client, "request")
+    def test_stops_on_empty_page(self, mock_request: MagicMock) -> None:
+        mock_request.side_effect = [
+            _json({"markets": [{"id": 1}, {"id": 2}]}),
+            _json({"markets": []}),
+        ]
+        client = PolymarketUS()
+
+        markets = list(client.markets.iterate(page_size=2))
+
+        assert [m["id"] for m in markets] == [1, 2]
+        assert mock_request.call_count == 2
+
+    @patch.object(httpx.Client, "request")
+    def test_single_short_page_stops_immediately(self, mock_request: MagicMock) -> None:
+        mock_request.side_effect = [_json({"series": [{"id": 1}]})]
+        client = PolymarketUS()
+
+        series = list(client.series.iterate(page_size=2))
+
+        assert [s["id"] for s in series] == [1]
+        assert mock_request.call_count == 1
+
+
+class TestCursorPagination:
+    """Cursor-based iterator (activities)."""
+
+    @patch.object(httpx.Client, "request")
+    def test_follows_cursor_until_eof(self, mock_request: MagicMock) -> None:
+        mock_request.side_effect = [
+            _json({"activities": [{"type": "a"}], "nextCursor": "c1", "eof": False}),
+            _json({"activities": [{"type": "b"}], "eof": True}),
+        ]
+        client = PolymarketUS(key_id="k", secret_key=TEST_SECRET_KEY)
+
+        activities = list(client.portfolio.iterate_activities())
+
+        assert [a["type"] for a in activities] == ["a", "b"]
+        assert mock_request.call_count == 2
+
+    @patch.object(httpx.Client, "request")
+    def test_stops_when_no_next_cursor(self, mock_request: MagicMock) -> None:
+        mock_request.side_effect = [
+            _json({"activities": [{"type": "a"}], "nextCursor": "", "eof": False}),
+        ]
+        client = PolymarketUS(key_id="k", secret_key=TEST_SECRET_KEY)
+
+        activities = list(client.portfolio.iterate_activities())
+
+        assert [a["type"] for a in activities] == ["a"]
+        assert mock_request.call_count == 1
+
+
+class TestAsyncPagination:
+    """Async iterators mirror the sync behavior."""
+
+    @patch.object(httpx.AsyncClient, "request", new_callable=AsyncMock)
+    async def test_async_offset_iterate(self, mock_request: AsyncMock) -> None:
+        mock_request.side_effect = [
+            _json({"events": [{"id": 1}, {"id": 2}]}),
+            _json({"events": [{"id": 3}]}),
+        ]
+        client = AsyncPolymarketUS()
+
+        events = [e async for e in client.events.iterate(page_size=2)]
+
+        assert [e["id"] for e in events] == [1, 2, 3]
+        await client.close()
+
+    @patch.object(httpx.AsyncClient, "request", new_callable=AsyncMock)
+    async def test_async_cursor_iterate(self, mock_request: AsyncMock) -> None:
+        mock_request.side_effect = [
+            _json({"activities": [{"type": "a"}], "nextCursor": "c1", "eof": False}),
+            _json({"activities": [{"type": "b"}], "eof": True}),
+        ]
+        client = AsyncPolymarketUS(key_id="k", secret_key=TEST_SECRET_KEY)
+
+        activities = [a async for a in client.portfolio.iterate_activities()]
+
+        assert [a["type"] for a in activities] == ["a", "b"]
+        await client.close()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -43,6 +43,20 @@ class TestOffsetPagination:
         assert mock_request.call_count == 2
 
     @patch.object(httpx.Client, "request")
+    def test_non_positive_page_size_terminates(self, mock_request: MagicMock) -> None:
+        # page_size <= 0 must be clamped so the loop cannot spin forever.
+        mock_request.side_effect = [
+            _json({"events": [{"id": 1}]}),
+            _json({"events": []}),
+        ]
+        client = PolymarketUS()
+
+        events = list(client.events.iterate(page_size=0))
+
+        assert [e["id"] for e in events] == [1]
+        assert mock_request.call_count == 2
+
+    @patch.object(httpx.Client, "request")
     def test_single_short_page_stops_immediately(self, mock_request: MagicMock) -> None:
         mock_request.side_effect = [_json({"series": [{"id": 1}]})]
         client = PolymarketUS()


### PR DESCRIPTION
## summary
adds `iterate()` helpers that transparently walk all pages so callers no longer hand-roll cursor/offset logic:

- offset-paginated resources: `events.iterate()`, `markets.iterate()`, `series.iterate()` (page until a short page is returned).
- cursor-paginated feed: `portfolio.iterate_activities()` (follow `nextCursor` until `eof` or an empty cursor).
- shared helpers live in `polymarket_us/pagination.py`; both sync (`Iterator`) and async (`AsyncIterator`) variants are provided.

positions are intentionally not iterated (the endpoint returns the full set in one response).

## test plan
- [x] `ruff check` / `ruff format --check`
- [x] `mypy polymarket_us`
- [x] `pytest` (125 passed; new `tests/test_pagination.py` covers offset paging until short/empty page, cursor paging until eof/no-next-cursor, and async variants)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive client-side helpers and documentation; no changes to signing, orders, or server contracts beyond extra list requests when iterating.
> 
> **Overview**
> Adds **auto-pagination** so callers can stream full list results without manual `offset`/`cursor` handling. Shared logic in `polymarket_us/pagination.py` covers **offset** pages (stop on short/empty page, clamp `page_size` to at least 1) and **cursor** pages (follow `nextCursor` until `eof` or missing cursor), with sync and async variants.
> 
> **`iterate()`** on `events`, `markets`, and `series` walks offset-paginated lists (optional filters + `page_size`). **`portfolio.iterate_activities()`** walks authenticated activity history via cursor. README documents sync/`async for` usage.
> 
> Tests in `tests/test_pagination.py` cover multi-page offset, empty pages, cursor/`eof`, and async mirrors. **`test_auth`** now builds a valid 64-byte base64 secret for the Ed25519 key-length test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfd4f3771e0492b98a618b242514709cfbeb981d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->