### PR TITLE
Fix types to allow fractional order quantities

### DIFF
--- a/polymarket_us/types/orders.py
+++ b/polymarket_us/types/orders.py
@@ -75,9 +75,9 @@ class Order(TypedDict, total=False):
     side: OrderSide
     type: OrderType
     price: Amount
-    quantity: int
-    cumQuantity: int
-    leavesQuantity: int
+    quantity: int | float
+    cumQuantity: int | float
+    leavesQuantity: int | float
     tif: TimeInForce
     goodTillTime: str
     intent: OrderIntent
@@ -115,7 +115,7 @@ class CreateOrderParams(TypedDict, total=False):
     intent: OrderIntent  # Required
     type: OrderType
     price: Amount
-    quantity: int
+    quantity: int | float
     tif: TimeInForce
     participateDontInitiate: bool
     goodTillTime: str
@@ -138,7 +138,7 @@ class ModifyOrderParams(TypedDict, total=False):
 
     marketSlug: str  # Required
     price: Amount
-    quantity: int
+    quantity: int | float
     tif: TimeInForce
     participateDontInitiate: bool
     goodTillTime: str


### PR DESCRIPTION
The order API supports fractional quantities for markets whose `minimumTradeQty` is below one, and order responses can contain fractional `quantity`, `cumQuantity`, and `leavesQuantity` values. The current TypedDicts declare all five order quantity fields as `int`, so static type checkers reject valid create/modify requests and incorrectly describe fractional responses.

This changes those annotations to `int | float`. Keeping `int` in the union preserves the natural whole-contract call shape while accurately accepting the decimal JSON numbers supported by the API.

Example currently rejected by mypy/pyright:

```python
from polymarket_us.types.orders import CreateOrderParams

params: CreateOrderParams = {
    "marketSlug": "example-market",
    "intent": "ORDER_INTENT_BUY_LONG",
    "quantity": 0.84,
}
```

Affected fields:

- `Order.quantity`
- `Order.cumQuantity`
- `Order.leavesQuantity`
- `CreateOrderParams.quantity`
- `ModifyOrderParams.quantity`

If maintainers prefer a single numeric alias, the same change could use a `Quantity = int | float` alias. `Decimal` is not appropriate for response typing unless the SDK JSON decoder is also configured to return `Decimal`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only annotation changes with no runtime behavior; low risk aside from slightly broader static typing for quantity fields.
> 
> **Overview**
> Updates order-related **TypedDict** annotations so quantity fields match the API’s support for fractional sizes (e.g. when a market’s minimum trade size is below one).
> 
> **`quantity`**, **`cumQuantity`**, and **`leavesQuantity`** on **`Order`**, plus **`quantity`** on **`CreateOrderParams`** and **`ModifyOrderParams`**, are now typed as **`int | float`** instead of **`int`**. Whole-number quantities remain valid; static checkers no longer reject decimal literals in create/modify payloads or mis-type fractional values in responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af0e3b9e5357f9c52be0863229cca52015abef7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->